### PR TITLE
fix: better custom types handling

### DIFF
--- a/godump.go
+++ b/godump.go
@@ -216,7 +216,7 @@ func printValue(tw *tabwriter.Writer, v reflect.Value, indent int, visited map[u
 		t := v.Type()
 		fmt.Fprintf(tw, "%s ", colorize(colorGray, "#"+t.String()))
 		fmt.Fprintln(tw)
-		for i := 0; i < v.NumField(); i++ {
+		for i, _ := range reflect.VisibleFields(t) {
 			field := t.Field(i)
 			fieldVal := v.Field(i)
 			symbol := "+"
@@ -256,7 +256,7 @@ func printValue(tw *tabwriter.Writer, v reflect.Value, indent int, visited map[u
 		fmt.Fprint(tw, "}")
 	case reflect.Slice, reflect.Array:
 		fmt.Fprintln(tw, "[")
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			if i >= maxItems {
 				indentPrint(tw, indent+1, colorize(colorGray, "... (truncated)\n"))
 				break

--- a/godump.go
+++ b/godump.go
@@ -149,6 +149,7 @@ func findFirstNonInternalFrame() (string, int) {
 	return "", 0
 }
 
+// callerLocation returns the file and line number of the caller at the specified skip level.
 func callerLocation(skip int) (string, int) {
 	_, file, line, ok := runtime.Caller(skip)
 	if !ok {
@@ -157,6 +158,7 @@ func callerLocation(skip int) (string, int) {
 	return file, line
 }
 
+// writeDump writes the values to the tabwriter, handling references and indentation.
 func writeDump(tw *tabwriter.Writer, vs ...any) {
 	referenceMap = map[uintptr]int{} // reset each time
 	visited := map[uintptr]bool{}
@@ -168,6 +170,7 @@ func writeDump(tw *tabwriter.Writer, vs ...any) {
 	}
 }
 
+// printValue recursively prints the value with indentation and handles references.
 func printValue(tw *tabwriter.Writer, v reflect.Value, indent int, visited map[uintptr]bool) {
 	if indent > maxDepth {
 		fmt.Fprint(tw, colorize(colorGray, "... (max depth)"))
@@ -294,6 +297,7 @@ func printValue(tw *tabwriter.Writer, v reflect.Value, indent int, visited map[u
 	}
 }
 
+// asStringer checks if the value implements fmt.Stringer and returns its string representation.
 func asStringer(v reflect.Value) string {
 	val := v
 	if !val.CanInterface() {
@@ -311,10 +315,12 @@ func asStringer(v reflect.Value) string {
 	return ""
 }
 
+// indentPrint prints indented text to the tabwriter.
 func indentPrint(tw *tabwriter.Writer, indent int, text string) {
 	fmt.Fprint(tw, strings.Repeat(" ", indent*indentWidth)+text)
 }
 
+// forceExported returns a value that is guaranteed to be exported, even if it is unexported.
 func forceExported(v reflect.Value) reflect.Value {
 	if v.CanInterface() {
 		return v
@@ -326,6 +332,7 @@ func forceExported(v reflect.Value) reflect.Value {
 	return v
 }
 
+// makeAddressable ensures the value is addressable, wrapping structs in pointers if necessary.
 func makeAddressable(v reflect.Value) reflect.Value {
 	// Already addressable? Do nothing
 	if v.CanAddr() {
@@ -342,6 +349,7 @@ func makeAddressable(v reflect.Value) reflect.Value {
 	return v
 }
 
+// isNil checks if the value is nil based on its kind.
 func isNil(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface, reflect.Func, reflect.Chan:
@@ -351,6 +359,7 @@ func isNil(v reflect.Value) bool {
 	}
 }
 
+// escapeControl escapes control characters in a string for safe display.
 func escapeControl(s string) string {
 	replacer := strings.NewReplacer(
 		"\n", `\n`,
@@ -363,6 +372,7 @@ func escapeControl(s string) string {
 	return replacer.Replace(s)
 }
 
+// detectColor checks environment variables to determine if color output should be enabled.
 func detectColor() bool {
 	if os.Getenv("NO_COLOR") != "" {
 		return false

--- a/godump_test.go
+++ b/godump_test.go
@@ -430,3 +430,60 @@ func TestSafeStringerCall(t *testing.T) {
 	assert.Contains(t, out, "(nil)")
 	assert.NotContains(t, out, "should never be called") // ensure String() wasn't called
 }
+
+func TestTimePointersEqual(t *testing.T) {
+	now := time.Now()
+	later := now.Add(time.Hour)
+
+	type testCase struct {
+		name     string
+		a        *time.Time
+		b        *time.Time
+		expected bool
+	}
+
+	tests := []testCase{
+		{
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "one nil",
+			a:        &now,
+			b:        nil,
+			expected: false,
+		},
+		{
+			name:     "equal times",
+			a:        &now,
+			b:        &now,
+			expected: true,
+		},
+		{
+			name:     "different times",
+			a:        &now,
+			b:        &later,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			equal := timePtrsEqual(tt.a, tt.b)
+			assert.Equal(t, tt.expected, equal)
+			Dump(tt)
+		})
+	}
+}
+
+func timePtrsEqual(a, b *time.Time) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Equal(*b)
+}


### PR DESCRIPTION
This PR enhances `godump` to fully support introspection of private struct fields, including:

* **Support for unexported `fmt.Stringer` values** via `forceExported()` and `asStringer()` logic
* **Automatic pointer wrapping** in `writeDump()` to ensure fields are addressable when passed by value
* **Cleaner handling of zero and nil values**, with `<invalid>` safely rendered for uninitialized fields
* **Redundant `time.Time` special-case removed**, now universally handled by generalized `Stringer` logic
* **No more panic fallbacks** — all access is guarded, safe, and cleanly formatted

Example:

```go
package main

import (
	"errors"
	"fmt"
	"test/internal/godump"
	"time"
)

type FriendlyDuration time.Duration

const maxVal = int64(time.Hour * 24)

var ErrOutOfBoundsDuration error = errors.New("FriendlyDuration cannot hold more than 23:59:59")

func NewFriendlyDurationFromString(v string) (_ FriendlyDuration, err error) {
	var td time.Duration
	td, err = parseValue(v)
	if err != nil {
		return 0, err
	}

	if int64(td) < maxVal {
		return FriendlyDuration(td), nil
	}

	return 0, ErrOutOfBoundsDuration
}

func (fd FriendlyDuration) MarshalText() (_ []byte, err error) {
	return []byte(fd.String()), nil
}

func (fd *FriendlyDuration) UnmarshalText(text []byte) (err error) {
	if len(text) < 1 {
		return fmt.Errorf("invalid text")
	}

	var td time.Duration
	td, err = parseValue(string(text))
	if err == nil {
		*fd = FriendlyDuration(td)
	}
	return err
}

func (fd FriendlyDuration) String() string {
	var td time.Duration = time.Duration(fd)
	return fmt.Sprintf("%02d:%02d:%02d", int(td.Hours()), int(td.Minutes())%60, int(td.Seconds())%60)
}

func (fd FriendlyDuration) Duration() time.Duration {
	return time.Duration(fd)
}

func parseValue(v string) (td time.Duration, err error) {
	var (
		h int64
		m int64
		s int64
		i int
	)
	i, err = fmt.Sscanf(v, "%d:%d:%d", &h, &m, &s)
	if i == 3 && err == nil {
		td = time.Hour*time.Duration(h) + time.Minute*time.Duration(m) + time.Second*time.Duration(s)
		if int64(td) > maxVal {
			err = ErrOutOfBoundsDuration
		}
	}

	return td, err
}

func main() {
	type SomeStruct struct {
		Name string
		Dur  time.Duration
		fd   FriendlyDuration
		Fd   FriendlyDuration
	}
	fd, err := NewFriendlyDurationFromString("0:0:0")
	if err != nil {
		fmt.Println(err)
	}

	ss := SomeStruct{
		Name: "Test",
		Dur:  time.Duration(time.Hour*23 + time.Minute*59 + time.Second*59),
		fd:   fd,
		Fd:   FriendlyDuration(time.Hour*23 + time.Minute*59 + time.Second*59),
	}

	// Pretty-print to stdout
	godump.Dump(ss)
	godump.Dump(fd)
	godump.Dump(NewFriendlyDurationFromString("20:0:0"))
}
```

Now outputs

![image](https://github.com/user-attachments/assets/27dea093-f6c1-423e-ba26-f1b115ac1dc1)

Another test

```go
package main

import (
	"fmt"
	"test/internal/godump"
	"time"
)

type FriendlyDuration time.Duration

func (fd FriendlyDuration) String() string {
	td := time.Duration(fd)
	return fmt.Sprintf("%02d:%02d:%02d", int(td.Hours()), int(td.Minutes())%60, int(td.Seconds())%60)
}

type Inner struct {
	ID    int
	Notes []string
}

type Ref struct {
	Self *Ref
}

type Everything struct {
	String        string
	Bool          bool
	Int           int
	Float         float64
	Time          time.Time
	Duration      time.Duration
	Friendly      FriendlyDuration
	PtrString     *string
	PtrDuration   *time.Duration
	SliceInts     []int
	ArrayStrings  [2]string
	MapValues     map[string]int
	Nested        Inner
	NestedPtr     *Inner
	Interface     any
	Recursive     *Ref
	privateField  string
	privateStruct Inner
}

func main() {
	now := time.Now()
	ptrStr := "Hello"
	dur := time.Minute * 20

	val := Everything{
		String:        "test",
		Bool:          true,
		Int:           42,
		Float:         3.1415,
		Time:          now,
		Duration:      dur,
		Friendly:      FriendlyDuration(dur),
		PtrString:     &ptrStr,
		PtrDuration:   &dur,
		SliceInts:     []int{1, 2, 3},
		ArrayStrings:  [2]string{"foo", "bar"},
		MapValues:     map[string]int{"a": 1, "b": 2},
		Nested:        Inner{ID: 10, Notes: []string{"alpha", "beta"}},
		NestedPtr:     &Inner{ID: 99, Notes: []string{"x", "y"}},
		Interface:     map[string]bool{"ok": true},
		Recursive:     &Ref{},
		privateField:  "should show",
		privateStruct: Inner{ID: 5, Notes: []string{"private"}},
	}
	val.Recursive.Self = val.Recursive // cycle

	godump.Dump(val)
}
```

![image](https://github.com/user-attachments/assets/6fd15369-d22f-4f07-a731-8382a79220b6)
![image](https://github.com/user-attachments/assets/62f5b60d-bb28-4393-93bf-c257dc238455)

