### PR TITLE
fix: prevent panic when dumping structs with promoted fields

### DIFF
--- a/godump.go
+++ b/godump.go
@@ -216,11 +216,11 @@ func printValue(tw *tabwriter.Writer, v reflect.Value, indent int, visited map[u
 		t := v.Type()
 		fmt.Fprintf(tw, "%s ", colorize(colorGray, "#"+t.String()))
 		fmt.Fprintln(tw)
-		for i, _ := range reflect.VisibleFields(t) {
-			field := t.Field(i)
-			fieldVal := v.Field(i)
+		visibleFields := reflect.VisibleFields(t)
+		for _, field := range visibleFields {
+			fieldVal := v.FieldByIndex(field.Index)
 			symbol := "+"
-			if field.PkgPath != "" { // private
+			if field.PkgPath != "" {
 				symbol = "-"
 				fieldVal = forceExported(fieldVal)
 			}

--- a/godump_test.go
+++ b/godump_test.go
@@ -487,3 +487,88 @@ func timePtrsEqual(a, b *time.Time) bool {
 	}
 	return a.Equal(*b)
 }
+
+func TestPanicOnVisibleFieldsIndexMismatch(t *testing.T) {
+	type Embedded struct {
+		Secret string
+	}
+	type Outer struct {
+		Embedded // Promoted field
+		Age      int
+	}
+
+	// This will panic with:
+	// panic: reflect: Field index out of bounds
+	_ = DumpStr(Outer{
+		Embedded: Embedded{Secret: "classified"},
+		Age:      42,
+	})
+}
+
+type FriendlyDuration time.Duration
+
+func (fd FriendlyDuration) String() string {
+	td := time.Duration(fd)
+	return fmt.Sprintf("%02d:%02d:%02d", int(td.Hours()), int(td.Minutes())%60, int(td.Seconds())%60)
+}
+
+func TestTheKitchenSink(t *testing.T) {
+
+	type Inner struct {
+		ID    int
+		Notes []string
+	}
+
+	type Ref struct {
+		Self *Ref
+	}
+
+	type Everything struct {
+		String        string
+		Bool          bool
+		Int           int
+		Float         float64
+		Time          time.Time
+		Duration      time.Duration
+		Friendly      FriendlyDuration
+		PtrString     *string
+		PtrDuration   *time.Duration
+		SliceInts     []int
+		ArrayStrings  [2]string
+		MapValues     map[string]int
+		Nested        Inner
+		NestedPtr     *Inner
+		Interface     any
+		Recursive     *Ref
+		privateField  string
+		privateStruct Inner
+	}
+
+	now := time.Now()
+	ptrStr := "Hello"
+	dur := time.Minute * 20
+
+	val := Everything{
+		String:        "test",
+		Bool:          true,
+		Int:           42,
+		Float:         3.1415,
+		Time:          now,
+		Duration:      dur,
+		Friendly:      FriendlyDuration(dur),
+		PtrString:     &ptrStr,
+		PtrDuration:   &dur,
+		SliceInts:     []int{1, 2, 3},
+		ArrayStrings:  [2]string{"foo", "bar"},
+		MapValues:     map[string]int{"a": 1, "b": 2},
+		Nested:        Inner{ID: 10, Notes: []string{"alpha", "beta"}},
+		NestedPtr:     &Inner{ID: 99, Notes: []string{"x", "y"}},
+		Interface:     map[string]bool{"ok": true},
+		Recursive:     &Ref{},
+		privateField:  "should show",
+		privateStruct: Inner{ID: 5, Notes: []string{"private"}},
+	}
+	val.Recursive.Self = val.Recursive // cycle
+
+	Dump(val)
+}


### PR DESCRIPTION
### 🔧 Fix: Prevent panic when dumping structs with promoted fields

**Summary:**

* Fixes a `panic: reflect: Field index out of bounds` when dumping structs that embed other structs (i.e. promoted fields).
* Replaces incorrect use of `t.Field(i)` with `reflect.VisibleFields(t)` + `FieldByIndex`, which safely handles embedded/promoted fields.

**Before:**

```go
for i := range reflect.VisibleFields(t) {
    field := t.Field(i) // ❌ may panic
```

**After:**

```go
for _, field := range reflect.VisibleFields(t) {
    fieldVal := v.FieldByIndex(field.Index) // ✅ safe
```

**Test added:**
✅ `TestPanicOnVisibleFieldsIndexMismatch` — reproduces panic with embedded struct and confirms resolution.


**Test Before**

```
=== RUN   TestPanicOnVisibleFieldsIndexMismatch
--- FAIL: TestPanicOnVisibleFieldsIndexMismatch (0.00s)
panic: reflect: Field index out of bounds [recovered]
	panic: reflect: Field index out of bounds

goroutine 35 [running]:
testing.tRunner.func1.2({0x100b11d40, 0x100b59130})
	/Users/cmiles/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/testing/testing.go:1632 +0x1bc
testing.tRunner.func1()
	/Users/cmiles/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/testing/testing.go:1635 +0x334
panic({0x100b11d40?, 0x100b59130?})
	/Users/cmiles/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/runtime/panic.go:785 +0x124
reflect.(*structType).Field(0x1479499f8?, 0x0?)
	/Users/cmiles/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/reflect/type.go:1116 +0x164
reflect.(*rtype).Field(0x100b59e38?, 0x14000144210?)
	/Users/cmiles/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/reflect/type.go:749 +0x50
github.com/goforj/godump.printValue(0x14000144210, {0x100b2d0e0?, 0x140001401e0?, 0x10090831c?}, 0x0, 0x14000175e78)
	/Users/cmiles/code/godump/godump.go:220 +0x1038
github.com/goforj/godump.writeDump(0x14000144210, {0x1400011af48, 0x1, 0x1400011af08?})
	/Users/cmiles/code/godump/godump.go:168 +0xc4
github.com/goforj/godump.DumpStr({0x1400011af48, 0x1, 0x1})
	/Users/cmiles/code/godump/godump.go:83 +0x94
github.com/goforj/godump.TestPanicOnVisibleFieldsIndexMismatch(0x14000134820?)
	/Users/cmiles/code/godump/godump_test.go:502 +0x68
testing.tRunner(0x14000134820, 0x100b57b98)
	/Users/cmiles/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/testing/testing.go:1690 +0xe4
created by testing.(*T).Run in goroutine 1
	/Users/cmiles/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.darwin-arm64/src/testing/testing.go:1743 +0x314
```

**Test After**

```
=== RUN   TestPanicOnVisibleFieldsIndexMismatch
--- PASS: TestPanicOnVisibleFieldsIndexMismatch (0.00s)
PASS

Process finished with the exit code 0

```