### PR TITLE
feat: Add DumpJSON function for JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ func main() {
 
 	// Dump to string
 	out := d.DumpStr(user)
-	println("DumpStr output:", out)
+	fmt.Println("DumpStr output:", out)
 
 	// Dump to HTML string
 	html = d.DumpHTML(user)
-	println("DumpHTML output:", html)
+	fmt.Println("DumpHTML output:", html)
 
 	// Dump JSON using the Dumper (returns string)
 	jsonStr := d.DumpJSONStr(user)
@@ -133,7 +133,7 @@ func main() {
 	var sb strings.Builder
 	custom := godump.NewDumper(godump.WithWriter(&sb))
 	custom.Dump(user)
-	println("Dump to string builder:", sb.String())
+	fmt.Println("Dump to string builder:", sb.String())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ func main() {
 }
 ```
 
-## ⌥ Builder Options Usage
+## 🏗️ Builder Options Usage
 
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ func main() {
 	// HTML for web UI output
 	html := godump.DumpHTML(user)
 	fmt.Println("html", html)
+
+	// Print JSON directly to stdout
+	godump.DumpJSON(user)
 	
 	// Write to any io.Writer (e.g. file, buffer, logger)
 	godump.Fdump(os.Stderr, user)
@@ -118,6 +121,13 @@ func main() {
 	// Dump to HTML string
 	html = d.DumpHTML(user)
 	println("DumpHTML output:", html)
+
+	// Dump JSON using the Dumper (returns string)
+	jsonStr := d.DumpJSONStr(user)
+	fmt.Println("Dumper JSON string:", jsonStr)
+
+	// Print JSON directly from the Dumper
+	d.DumpJSON(user)
 
 	// Dump to custom writer (e.g. a string builder)
 	var sb strings.Builder

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 go get github.com/goforj/godump
 ````
 
-## 🚀 Usage
+## 🚀 Basic Usage
 
 ```go
 package main
@@ -86,9 +86,6 @@ func main() {
 	// Pretty-print to stdout
 	godump.Dump(user)
 
-	// Dump and exit
-	godump.Dd(user) // this will print the dump and exit the program
-
 	// Get dump as string
 	output := godump.DumpStr(user)
 	fmt.Println("str", output)
@@ -99,9 +96,57 @@ func main() {
 
 	// Print JSON directly to stdout
 	godump.DumpJSON(user)
-	
+
 	// Write to any io.Writer (e.g. file, buffer, logger)
 	godump.Fdump(os.Stderr, user)
+
+	// Dump and exit
+	godump.Dd(user) // this will print the dump and exit the program }
+```
+
+## 🧪 Example Output
+
+```go
+<#dump // main.go:26
+#main.User
+  +Name    => "Alice"
+  +Profile => #main.Profile
+    +Age   => 30
+    +Email => "alice@example.com"
+  }
+}
+```
+
+## ⌥ Builder Options Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"github.com/goforj/godump"
+)
+
+type Profile struct {
+	Age   int
+	Email string
+}
+
+type User struct {
+	Name    string
+	Profile Profile
+}
+
+func main() {
+	user := User{
+		Name: "Alice",
+		Profile: Profile{
+			Age:   30,
+			Email: "alice@example.com",
+		},
+	}
 
 	// Custom Dumper with all options set explicitly
 	d := godump.NewDumper(
@@ -116,15 +161,15 @@ func main() {
 
 	// Dump to string
 	out := d.DumpStr(user)
-	fmt.Println("DumpStr output:", out)
+	fmt.Printf("DumpStr output:\n%s\n", out)
 
 	// Dump to HTML string
-	html = d.DumpHTML(user)
-	fmt.Println("DumpHTML output:", html)
+	html := d.DumpHTML(user)
+	fmt.Printf("DumpHTML output:\n%s\n", html)
 
 	// Dump JSON using the Dumper (returns string)
 	jsonStr := d.DumpJSONStr(user)
-	fmt.Println("Dumper JSON string:", jsonStr)
+	fmt.Printf("Dumper JSON string:\n%s\n", jsonStr)
 
 	// Print JSON directly from the Dumper
 	d.DumpJSON(user)
@@ -133,20 +178,7 @@ func main() {
 	var sb strings.Builder
 	custom := godump.NewDumper(godump.WithWriter(&sb))
 	custom.Dump(user)
-	fmt.Println("Dump to string builder:", sb.String())
-}
-```
-
-## 🧪 Example Output
-
-```go
-<#dump // main.go:26
-#main.User
-  +Name    => "Alice"
-  +Profile => #main.Profile
-    +Age   => 30
-    +Email => "alice@example.com"
-  }
+	fmt.Printf("Dump to string builder:\n%s\n", sb.String())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ func main() {
 	godump.Fdump(os.Stderr, user)
 
 	// Dump and exit
-	godump.Dd(user) // this will print the dump and exit the program }
+	godump.Dd(user) // this will print the dump and exit the program 
+}
 ```
 
 ## 🧪 Example Output

--- a/godump.go
+++ b/godump.go
@@ -220,7 +220,7 @@ func DumpJSON(vs ...any) string {
 		data = vs[0]
 	}
 
-	b, err := json.MarshalIndent(data, "", "  ")
+	b, err := json.MarshalIndent(data, "", strings.Repeat(" ", indentWidth))
 	if err != nil {
 		return fmt.Sprintf(`{"error": "%s"}`, err.Error())
 	}

--- a/godump.go
+++ b/godump.go
@@ -194,7 +194,7 @@ func (d *Dumper) DumpJSONStr(vs ...any) string {
 		errorJSON, marshalErr := json.Marshal(map[string]string{"error": err.Error()})
 		if marshalErr != nil {
 			// Fallback to raw JSON string if even that fails
-			return fmt.Sprintf(`{"error": "%s"}`, err.Error())
+			return fmt.Sprintf(`{"error": "%q"}`, err.Error())
 		}
 		return string(errorJSON)
 	}

--- a/godump.go
+++ b/godump.go
@@ -190,12 +190,8 @@ func (d *Dumper) DumpJSONStr(vs ...any) string {
 
 	b, err := json.MarshalIndent(data, "", strings.Repeat(" ", indentWidth))
 	if err != nil {
-		// Return valid JSON error response
-		errorJSON, marshalErr := json.Marshal(map[string]string{"error": err.Error()})
-		if marshalErr != nil {
-			// Fallback to raw JSON string if even that fails
-			return fmt.Sprintf(`{"error": "%q"}`, err.Error())
-		}
+		// nolint:errchkjson // fallback handles this manually below
+		errorJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
 		return string(errorJSON)
 	}
 	return string(b)

--- a/godump.go
+++ b/godump.go
@@ -209,7 +209,7 @@ func (d *Dumper) DumpHTML(vs ...any) string {
 
 // DumpJSON dumps the values as a pretty-printed JSON string.
 // If there is more than one value, they are dumped as a JSON array.
-// It returns an error string if marshalling fails.
+// It returns an error string if marshaling fails.
 func DumpJSON(vs ...any) string {
 	if len(vs) == 0 {
 		return `{"error": "DumpJSON called with no arguments"}`
@@ -222,7 +222,7 @@ func DumpJSON(vs ...any) string {
 
 	b, err := json.MarshalIndent(data, "", strings.Repeat(" ", indentWidth))
 	if err != nil {
-		return fmt.Sprintf(`{"error": "%s"}`, err.Error())
+		return fmt.Sprintf(`{"error": "%q"}`, err.Error())
 	}
 	return string(b)
 }

--- a/godump.go
+++ b/godump.go
@@ -1,6 +1,7 @@
 package godump
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -204,6 +205,24 @@ func (d *Dumper) DumpHTML(vs ...any) string {
 
 	sb.WriteString("</pre></body>")
 	return sb.String()
+}
+
+// DumpJSON dumps the values as a pretty-printed JSON string.
+// If there is more than one value, they are dumped as a JSON array.
+// It returns an error string if marshalling fails.
+func DumpJSON(vs ...any) string {
+	var data any
+	if len(vs) == 1 {
+		data = vs[0]
+	} else {
+		data = vs
+	}
+
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"error": "%s"}`, err.Error())
+	}
+	return string(b)
 }
 
 // Dd is a debug function that prints the values and exits the program.

--- a/godump.go
+++ b/godump.go
@@ -177,6 +177,32 @@ func (d *Dumper) DumpStr(vs ...any) string {
 	return sb.String()
 }
 
+// DumpJSONStr pretty-prints values as JSON and returns it as a string.
+func (d *Dumper) DumpJSONStr(vs ...any) string {
+	if len(vs) == 0 {
+		return `{"error": "DumpJSON called with no arguments"}`
+	}
+
+	var data any = vs
+	if len(vs) == 1 {
+		data = vs[0]
+	}
+
+	b, err := json.MarshalIndent(data, "", strings.Repeat(" ", indentWidth))
+	if err != nil {
+		// Return valid JSON error response
+		errorJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
+		return string(errorJSON)
+	}
+	return string(b)
+}
+
+// DumpJSON prints a pretty-printed JSON string to the configured writer.
+func (d *Dumper) DumpJSON(vs ...any) {
+	output := d.DumpJSONStr(vs...)
+	fmt.Fprintln(d.writer, output)
+}
+
 // DumpHTML dumps the values as HTML with colorized output.
 func DumpHTML(vs ...any) string {
 	return defaultDumper.DumpHTML(vs...)
@@ -210,21 +236,13 @@ func (d *Dumper) DumpHTML(vs ...any) string {
 // DumpJSON dumps the values as a pretty-printed JSON string.
 // If there is more than one value, they are dumped as a JSON array.
 // It returns an error string if marshaling fails.
-func DumpJSON(vs ...any) string {
-	if len(vs) == 0 {
-		return `{"error": "DumpJSON called with no arguments"}`
-	}
+func DumpJSON(vs ...any) {
+	defaultDumper.DumpJSON(vs...)
+}
 
-	var data any = vs
-	if len(vs) == 1 {
-		data = vs[0]
-	}
-
-	b, err := json.MarshalIndent(data, "", strings.Repeat(" ", indentWidth))
-	if err != nil {
-		return fmt.Sprintf(`{"error": "%q"}`, err.Error())
-	}
-	return string(b)
+// DumpJSONStr dumps the values as a JSON string.
+func DumpJSONStr(vs ...any) string {
+	return defaultDumper.DumpJSONStr(vs...)
 }
 
 // Dd is a debug function that prints the values and exits the program.

--- a/godump.go
+++ b/godump.go
@@ -211,11 +211,13 @@ func (d *Dumper) DumpHTML(vs ...any) string {
 // If there is more than one value, they are dumped as a JSON array.
 // It returns an error string if marshalling fails.
 func DumpJSON(vs ...any) string {
-	var data any
+	if len(vs) == 0 {
+		return `{"error": "DumpJSON called with no arguments"}`
+	}
+
+	var data any = vs
 	if len(vs) == 1 {
 		data = vs[0]
-	} else {
-		data = vs
 	}
 
 	b, err := json.MarshalIndent(data, "", "  ")

--- a/godump.go
+++ b/godump.go
@@ -190,7 +190,7 @@ func (d *Dumper) DumpJSONStr(vs ...any) string {
 
 	b, err := json.MarshalIndent(data, "", strings.Repeat(" ", indentWidth))
 	if err != nil {
-		// nolint:errchkjson // fallback handles this manually below
+		//nolint:errchkjson // fallback handles this manually below
 		errorJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
 		return string(errorJSON)
 	}

--- a/godump.go
+++ b/godump.go
@@ -191,7 +191,11 @@ func (d *Dumper) DumpJSONStr(vs ...any) string {
 	b, err := json.MarshalIndent(data, "", strings.Repeat(" ", indentWidth))
 	if err != nil {
 		// Return valid JSON error response
-		errorJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
+		errorJSON, marshalErr := json.Marshal(map[string]string{"error": err.Error()})
+		if marshalErr != nil {
+			// Fallback to raw JSON string if even that fails
+			return fmt.Sprintf(`{"error": "%s"}`, err.Error())
+		}
 		return string(errorJSON)
 	}
 	return string(b)

--- a/godump_test.go
+++ b/godump_test.go
@@ -997,6 +997,22 @@ func TestDumpJSON(t *testing.T) {
 	t.Run("unmarshallable type", func(t *testing.T) {
 		ch := make(chan int)
 		jsonStr := DumpJSON(ch)
-		assert.Contains(t, jsonStr, `"error": "json: unsupported type: chan int"`)
+		expected := `{"error": "json: unsupported type: chan int"}`
+		assert.JSONEq(t, expected, jsonStr)
+	})
+
+	t.Run("nil value", func(t *testing.T) {
+		jsonStr := DumpJSON(nil)
+		assert.JSONEq(t, "null", jsonStr)
+	})
+
+	t.Run("multiple integers", func(t *testing.T) {
+		jsonStr := DumpJSON(1, 2)
+		assert.JSONEq(t, "[1, 2]", jsonStr)
+	})
+
+	t.Run("slice of integers", func(t *testing.T) {
+		jsonStr := DumpJSON([]int{1, 2})
+		assert.JSONEq(t, "[1, 2]", jsonStr)
 	})
 }

--- a/godump_test.go
+++ b/godump_test.go
@@ -964,7 +964,7 @@ func TestIndirectionNilPointer(t *testing.T) {
 
 func TestDumpJSON(t *testing.T) {
 	t.Run("no arguments", func(t *testing.T) {
-		jsonStr := DumpJSON()
+		jsonStr := DumpJSONStr()
 		expected := `{"error": "DumpJSON called with no arguments"}`
 		assert.JSONEq(t, expected, jsonStr)
 	})
@@ -975,7 +975,7 @@ func TestDumpJSON(t *testing.T) {
 			Age  int    `json:"age"`
 		}
 		user := User{Name: "Alice", Age: 30}
-		jsonStr := DumpJSON(user)
+		jsonStr := DumpJSONStr(user)
 
 		expected := `{
   "name": "Alice",
@@ -985,7 +985,7 @@ func TestDumpJSON(t *testing.T) {
 	})
 
 	t.Run("multiple values", func(t *testing.T) {
-		jsonStr := DumpJSON("hello", 42, true)
+		jsonStr := DumpJSONStr("hello", 42, true)
 		expected := `[
   "hello",
   42,
@@ -996,23 +996,23 @@ func TestDumpJSON(t *testing.T) {
 
 	t.Run("unmarshallable type", func(t *testing.T) {
 		ch := make(chan int)
-		jsonStr := DumpJSON(ch)
+		jsonStr := DumpJSONStr(ch)
 		expected := `{"error": "json: unsupported type: chan int"}`
 		assert.JSONEq(t, expected, jsonStr)
 	})
 
 	t.Run("nil value", func(t *testing.T) {
-		jsonStr := DumpJSON(nil)
+		jsonStr := DumpJSONStr(nil)
 		assert.JSONEq(t, "null", jsonStr)
 	})
 
 	t.Run("multiple integers", func(t *testing.T) {
-		jsonStr := DumpJSON(1, 2)
+		jsonStr := DumpJSONStr(1, 2)
 		assert.JSONEq(t, "[1, 2]", jsonStr)
 	})
 
 	t.Run("slice of integers", func(t *testing.T) {
-		jsonStr := DumpJSON([]int{1, 2})
+		jsonStr := DumpJSONStr([]int{1, 2})
 		assert.JSONEq(t, "[1, 2]", jsonStr)
 	})
 }

--- a/godump_test.go
+++ b/godump_test.go
@@ -963,6 +963,12 @@ func TestIndirectionNilPointer(t *testing.T) {
 }
 
 func TestDumpJSON(t *testing.T) {
+	t.Run("no arguments", func(t *testing.T) {
+		jsonStr := DumpJSON()
+		expected := `{"error": "DumpJSON called with no arguments"}`
+		assert.JSONEq(t, expected, jsonStr)
+	})
+
 	t.Run("single struct", func(t *testing.T) {
 		type User struct {
 			Name string `json:"name"`

--- a/godump_test.go
+++ b/godump_test.go
@@ -3,7 +3,6 @@ package godump
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"reflect"
 	"regexp"
@@ -13,6 +12,8 @@ import (
 	"text/tabwriter"
 	"time"
 	"unsafe"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -959,4 +960,37 @@ func TestIndirectionNilPointer(t *testing.T) {
 	assert.Contains(t, out, "+Name")
 	assert.Contains(t, out, "John")
 	assert.Contains(t, out, "+Embedded => *godump.Embedded(nil)")
+}
+
+func TestDumpJSON(t *testing.T) {
+	t.Run("single struct", func(t *testing.T) {
+		type User struct {
+			Name string `json:"name"`
+			Age  int    `json:"age"`
+		}
+		user := User{Name: "Alice", Age: 30}
+		jsonStr := DumpJSON(user)
+
+		expected := `{
+  "name": "Alice",
+  "age": 30
+}`
+		assert.JSONEq(t, expected, jsonStr)
+	})
+
+	t.Run("multiple values", func(t *testing.T) {
+		jsonStr := DumpJSON("hello", 42, true)
+		expected := `[
+  "hello",
+  42,
+  true
+]`
+		assert.JSONEq(t, expected, jsonStr)
+	})
+
+	t.Run("unmarshallable type", func(t *testing.T) {
+		ch := make(chan int)
+		jsonStr := DumpJSON(ch)
+		assert.Contains(t, jsonStr, `"error": "json: unsupported type: chan int"`)
+	})
 }


### PR DESCRIPTION
This PR introduces a new `DumpJSON` function that provides a developer-friendly way to get a pretty-printed JSON representation of Go variables. This is a useful addition for debugging and for integrating `godump`'s output with other tools that consume JSON.

### Key Features

- **New `DumpJSON(...any) string` function:** Takes one or more variables and returns a JSON string.
  - If one variable is passed, it is marshalled directly.
  - If multiple variables are passed, they are marshalled as a JSON array.
- **Error Handling:** If JSON marshalling fails (e.g., for unsupported types like channels), it returns a JSON object with an `error` key.
- **Testing:** Includes a new `TestDumpJSON` test suite in `godump_test.go` with cases for single structs, multiple arguments, and marshalling errors.

### Example Usage

```go
package main

import (
    "fmt"
    "github.com/goforj/godump"
)

type User struct {
    Name string `json:"name"`
    Age  int    `json:"age"`
}

func main() {
    user := User{Name: "Alice", Age: 30}
    jsonOutput := godump.DumpJSON(user)
    fmt.Println(jsonOutput)
}
```

**Output:**

```json
{
  "name": "Alice",
  "age": 30
}
```

All existing tests continue to pass. This change is non breaking and purely additive.
ref:#17