### PR TITLE
feat: allow user customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"github.com/goforj/godump"
 )
 
@@ -109,6 +110,20 @@ func main() {
 
 	// Use the custom dumper
 	d.Dump(user)
+
+	// Dump to string
+	out := d.DumpStr(user)
+	println("DumpStr output:", out)
+
+	// Dump to HTML string
+	html = d.DumpHTML(user)
+	println("DumpHTML output:", html)
+
+	// Dump to custom writer (e.g. a string builder)
+	var sb strings.Builder
+	custom := godump.NewDumper(godump.WithWriter(&sb))
+	custom.Dump(user)
+	println("Dump to string builder:", sb.String())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ func main() {
 	
 	// Write to any io.Writer (e.g. file, buffer, logger)
 	godump.Fdump(os.Stderr, user)
+
+	// Custom Dumper with all options set explicitly
+	d := godump.NewDumper(
+		godump.WithMaxDepth(15),          // default: 15
+		godump.WithMaxItems(100),         // default: 100
+		godump.WithMaxStringLen(100000),  // default: 100000
+		godump.WithWriter(os.Stdout),     // default: os.Stdout
+	)
+
+	// Use the custom dumper
+	d.Dump(user)
 }
 ```
 

--- a/godump.go
+++ b/godump.go
@@ -161,12 +161,12 @@ func Fdump(w io.Writer, vs ...any) {
 	NewDumper(WithWriter(w)).Dump(vs...)
 }
 
-// DumpStr dumps the values as a string with colorized output.
+// DumpStr returns a string representation of the values with colorized output.
 func DumpStr(vs ...any) string {
 	return defaultDumper.DumpStr(vs...)
 }
 
-// DumpStr dumps the values as a string with colorized output.
+// DumpStr returns a string representation of the values with colorized output.
 func (d *Dumper) DumpStr(vs ...any) string {
 	var sb strings.Builder
 	printDumpHeader(&sb, 3)

--- a/godump.go
+++ b/godump.go
@@ -95,7 +95,7 @@ func WithMaxDepth(n int) Option {
 	}
 }
 
-// WithMaxItems allows to control how much items from an array, slice or maps can be printed.
+// WithMaxItems allows to control how many items from an array, slice or maps can be printed.
 // Param n must be 0 or greater or this will be ignored, and default MaxItems will be 100
 func WithMaxItems(n int) Option {
 	return func(d *Dumper) *Dumper {
@@ -155,7 +155,7 @@ func (d *Dumper) Dump(vs ...any) {
 
 // Fdump writes the formatted dump of values to the given io.Writer.
 //
-// Deprecated, use NewDumper with WithWriter(w io.Writer) option
+// Deprecated: use NewDumper with WithWriter(w io.Writer) option
 func Fdump(w io.Writer, vs ...any) {
 	NewDumper(WithWriter(w)).Dump(vs...)
 }

--- a/godump.go
+++ b/godump.go
@@ -26,12 +26,17 @@ const (
 	indentWidth  = 2
 )
 
+const (
+	defaultMaxDepth     = 15
+	defaultMaxItems     = 100
+	defaultMaxStringLen = 100000
+)
+
+var defaultDumper = NewDumper()
+
 var exitFunc = os.Exit
 
 var (
-	maxDepth     = 15
-	maxItems     = 100
-	maxStringLen = 100000
 	enableColor  = detectColor()
 	nextRefID    = 1
 	referenceMap = map[uintptr]int{}
@@ -111,13 +116,13 @@ func WithMaxStringLen(n int) Option {
 	}
 }
 
-// WithOptions creates a new Dumper with the given options applied.
+// NewDumper creates a new Dumper with the given options applied.
 // Defaults are used for any setting not overridden.
-func WithOptions(opts ...Option) *Dumper {
+func NewDumper(opts ...Option) *Dumper {
 	d := &Dumper{
-		maxDepth:     maxDepth,
-		maxItems:     maxItems,
-		maxStringLen: maxStringLen,
+		maxDepth:     defaultMaxDepth,
+		maxItems:     defaultMaxItems,
+		maxStringLen: defaultMaxStringLen,
 	}
 	for _, opt := range opts {
 		d = opt(d)
@@ -127,7 +132,7 @@ func WithOptions(opts ...Option) *Dumper {
 
 // Dump prints the values to stdout with colorized output.
 func Dump(vs ...any) {
-	WithOptions().Dump(vs...)
+	defaultDumper.Dump(vs...)
 }
 
 // Dump prints the values to stdout with colorized output.
@@ -140,7 +145,7 @@ func (d *Dumper) Dump(vs ...any) {
 
 // Fdump writes the formatted dump of values to the given io.Writer.
 func Fdump(w io.Writer, vs ...any) {
-	WithOptions().Fdump(w, vs...)
+	defaultDumper.Fdump(w, vs...)
 }
 
 // Fdump writes the formatted dump of values to the given io.Writer.
@@ -153,7 +158,7 @@ func (d *Dumper) Fdump(w io.Writer, vs ...any) {
 
 // DumpStr dumps the values as a string with colorized output.
 func DumpStr(vs ...any) string {
-	return WithOptions().DumpStr(vs...)
+	return defaultDumper.DumpStr(vs...)
 }
 
 // DumpStr dumps the values as a string with colorized output.
@@ -168,7 +173,7 @@ func (d *Dumper) DumpStr(vs ...any) string {
 
 // DumpHTML dumps the values as HTML with colorized output.
 func DumpHTML(vs ...any) string {
-	return WithOptions().DumpHTML(vs...)
+	return defaultDumper.DumpHTML(vs...)
 }
 
 // DumpHTML dumps the values as HTML with colorized output.
@@ -198,7 +203,7 @@ func (d *Dumper) DumpHTML(vs ...any) string {
 
 // Dd is a debug function that prints the values and exits the program.
 func Dd(vs ...any) {
-	WithOptions().Dd(vs...)
+	defaultDumper.Dd(vs...)
 }
 
 // Dd is a debug function that prints the values and exits the program.
@@ -224,7 +229,6 @@ func printDumpHeader(out io.Writer, skip int) {
 	header := fmt.Sprintf("<#dump // %s:%d", relPath, line)
 	fmt.Fprintln(out, colorize(colorGray, header))
 }
-
 
 // findFirstNonInternalFrame finds the first non-internal frame in the call stack.
 var callerFn = runtime.Caller

--- a/godump.go
+++ b/godump.go
@@ -75,21 +75,32 @@ type dumper struct {
 
 type Option func(*dumper) *dumper
 
+// WithMaxDepth allows to control how deep the structure will be dumped. Param n must be 0 or greater or this will be ignored, and default MaxDepth will be 15
 func WithMaxDepth(n int) Option {
 	return func(d *dumper) *dumper {
-		d.maxDepth = n
+		if n >= 0 {
+			d.maxDepth = n
+		}
 		return d
 	}
 }
+
+// WithMaxItems allows to control how much items from an array, slice or maps can be printed. Param n must be 0 or greater or this will be ignored, and default MaxItems will be 100
 func WithMaxItems(n int) Option {
 	return func(d *dumper) *dumper {
-		d.maxItems = n
+		if n >= 0 {
+			d.maxItems = n
+		}
 		return d
 	}
 }
+
+// WithMaxStringLen allows to control how long can printed strings be. Param n must be 0 or greater or this will be ignored, and default MaxStringLen will be 100000
 func WithMaxStringLen(n int) Option {
 	return func(d *dumper) *dumper {
-		d.maxStringLen = n
+		if n >= 0 {
+			d.maxStringLen = n
+		}
 		return d
 	}
 }

--- a/godump.go
+++ b/godump.go
@@ -78,7 +78,8 @@ type Dumper struct {
 // Option defines a functional option for configuring a Dumper.
 type Option func(*Dumper) *Dumper
 
-// WithMaxDepth allows to control how deep the structure will be dumped. Param n must be 0 or greater or this will be ignored, and default MaxDepth will be 15
+// WithMaxDepth allows to control how deep the structure will be dumped.
+// Param n must be 0 or greater or this will be ignored, and default MaxDepth will be 15
 func WithMaxDepth(n int) Option {
 	return func(d *Dumper) *Dumper {
 		if n >= 0 {
@@ -88,7 +89,8 @@ func WithMaxDepth(n int) Option {
 	}
 }
 
-// WithMaxItems allows to control how much items from an array, slice or maps can be printed. Param n must be 0 or greater or this will be ignored, and default MaxItems will be 100
+// WithMaxItems allows to control how much items from an array, slice or maps can be printed.
+// Param n must be 0 or greater or this will be ignored, and default MaxItems will be 100
 func WithMaxItems(n int) Option {
 	return func(d *Dumper) *Dumper {
 		if n >= 0 {
@@ -98,7 +100,8 @@ func WithMaxItems(n int) Option {
 	}
 }
 
-// WithMaxStringLen allows to control how long can printed strings be. Param n must be 0 or greater or this will be ignored, and default MaxStringLen will be 100000
+// WithMaxStringLen allows to control how long can printed strings be.
+// Param n must be 0 or greater or this will be ignored, and default MaxStringLen will be 100000
 func WithMaxStringLen(n int) Option {
 	return func(d *Dumper) *Dumper {
 		if n >= 0 {

--- a/godump.go
+++ b/godump.go
@@ -108,6 +108,8 @@ func WithMaxStringLen(n int) Option {
 	}
 }
 
+// WithOptions creates a new Dumper with the given options applied.
+// Defaults are used for any setting not overridden.
 func WithOptions(opts ...Option) *Dumper {
 	d := &Dumper{
 		maxDepth:     maxDepth,

--- a/godump.go
+++ b/godump.go
@@ -26,14 +26,17 @@ const (
 	indentWidth  = 2
 )
 
+// Default configuration values for the Dumper.
 const (
 	defaultMaxDepth     = 15
 	defaultMaxItems     = 100
 	defaultMaxStringLen = 100000
 )
 
+// defaultDumper is the default Dumper instance used by Dump and DumpStr functions.
 var defaultDumper = NewDumper()
 
+// exitFunc is a function that can be overridden for testing purposes.
 var exitFunc = os.Exit
 
 var (
@@ -154,8 +157,6 @@ func (d *Dumper) Dump(vs ...any) {
 }
 
 // Fdump writes the formatted dump of values to the given io.Writer.
-//
-// Deprecated: use NewDumper with WithWriter(w io.Writer) option
 func Fdump(w io.Writer, vs ...any) {
 	NewDumper(WithWriter(w)).Dump(vs...)
 }
@@ -542,6 +543,7 @@ func isNil(v reflect.Value) bool {
 	}
 }
 
+// replacer is used to escape control characters in strings.
 var replacer = strings.NewReplacer(
 	"\n", `\n`,
 	"\t", `\t`,

--- a/godump_test.go
+++ b/godump_test.go
@@ -355,6 +355,12 @@ func TestCustomMaxDepthTruncation(t *testing.T) {
 
 	out := stripANSI(WithOptions(WithMaxDepth(2)).DumpStr(root))
 	assert.Contains(t, out, "... (max depth)")
+
+	out = stripANSI(WithOptions(WithMaxDepth(0)).DumpStr(root))
+	assert.Contains(t, out, "... (max depth)")
+
+	out = stripANSI(WithOptions(WithMaxDepth(-1)).DumpStr(root))
+	assert.NotContains(t, out, "... (max depth)")
 }
 
 func TestDetectColorEnvVars(t *testing.T) {
@@ -427,6 +433,16 @@ func TestCustomTruncatedSlice(t *testing.T) {
 	if !strings.Contains(out, "... (truncated)") {
 		t.Error("Expected slice to be truncated")
 	}
+
+	out = WithOptions(WithMaxItems(0)).DumpStr(slice)
+	if !strings.Contains(out, "... (truncated)") {
+		t.Error("Expected slice to be truncated")
+	}
+
+	out = WithOptions(WithMaxItems(-1)).DumpStr(slice)
+	if strings.Contains(out, "... (truncated)") {
+		t.Error("Negative MaxItems option should not be applied")
+	}
 }
 
 func TestTruncatedString(t *testing.T) {
@@ -442,6 +458,16 @@ func TestCustomTruncatedString(t *testing.T) {
 	out := WithOptions(WithMaxStringLen(9)).DumpStr(s)
 	if !strings.Contains(out, "…") {
 		t.Error("Expected long string to be truncated")
+	}
+
+	out = WithOptions(WithMaxStringLen(0)).DumpStr(s)
+	if !strings.Contains(out, "…") {
+		t.Error("Expected long string to be truncated")
+	}
+
+	out = WithOptions(WithMaxStringLen(-1)).DumpStr(s)
+	if strings.Contains(out, "…") {
+		t.Error("Negative MaxStringLen option should not be applied")
 	}
 }
 

--- a/godump_test.go
+++ b/godump_test.go
@@ -215,7 +215,7 @@ func TestUnreadableFallback(t *testing.T) {
 	var ch chan int // nil typed value, not interface
 	rv := reflect.ValueOf(ch)
 
-	WithOptions().printValue(tw, rv, 0, map[uintptr]bool{})
+	NewDumper().printValue(tw, rv, 0, map[uintptr]bool{})
 	tw.Flush()
 
 	output := stripANSI(b.String())
@@ -235,7 +235,7 @@ func TestUnreadableFieldFallback(t *testing.T) {
 	var sb strings.Builder
 	tw := tabwriter.NewWriter(&sb, 0, 0, 1, ' ', 0)
 
-	WithOptions().printValue(tw, v, 0, map[uintptr]bool{})
+	NewDumper().printValue(tw, v, 0, map[uintptr]bool{})
 	tw.Flush()
 
 	out := stripANSI(sb.String())
@@ -288,7 +288,7 @@ func TestDefaultFallback_Unreadable(t *testing.T) {
 
 	var buf strings.Builder
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	WithOptions().printValue(tw, v, 0, map[uintptr]bool{})
+	NewDumper().printValue(tw, v, 0, map[uintptr]bool{})
 	tw.Flush()
 
 	assert.Contains(t, buf.String(), "<invalid>")
@@ -299,7 +299,7 @@ func TestPrintValue_Uintptr(t *testing.T) {
 	val := uintptr(12345)
 	var buf strings.Builder
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	WithOptions().printValue(tw, reflect.ValueOf(val), 0, map[uintptr]bool{})
+	NewDumper().printValue(tw, reflect.ValueOf(val), 0, map[uintptr]bool{})
 	tw.Flush()
 
 	assert.Contains(t, buf.String(), "12345")
@@ -311,7 +311,7 @@ func TestPrintValue_UnsafePointer(t *testing.T) {
 	up := unsafe.Pointer(&i)
 	var buf strings.Builder
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	WithOptions().printValue(tw, reflect.ValueOf(up), 0, map[uintptr]bool{})
+	NewDumper().printValue(tw, reflect.ValueOf(up), 0, map[uintptr]bool{})
 	tw.Flush()
 
 	assert.Contains(t, buf.String(), "unsafe.Pointer")
@@ -321,7 +321,7 @@ func TestPrintValue_Func(t *testing.T) {
 	fn := func() {}
 	var buf strings.Builder
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	WithOptions().printValue(tw, reflect.ValueOf(fn), 0, map[uintptr]bool{})
+	NewDumper().printValue(tw, reflect.ValueOf(fn), 0, map[uintptr]bool{})
 	tw.Flush()
 
 	assert.Contains(t, buf.String(), "func(...) {...}")
@@ -353,13 +353,13 @@ func TestCustomMaxDepthTruncation(t *testing.T) {
 		curr = curr.Next
 	}
 
-	out := stripANSI(WithOptions(WithMaxDepth(2)).DumpStr(root))
+	out := stripANSI(NewDumper(WithMaxDepth(2)).DumpStr(root))
 	assert.Contains(t, out, "... (max depth)")
 
-	out = stripANSI(WithOptions(WithMaxDepth(0)).DumpStr(root))
+	out = stripANSI(NewDumper(WithMaxDepth(0)).DumpStr(root))
 	assert.Contains(t, out, "... (max depth)")
 
-	out = stripANSI(WithOptions(WithMaxDepth(-1)).DumpStr(root))
+	out = stripANSI(NewDumper(WithMaxDepth(-1)).DumpStr(root))
 	assert.NotContains(t, out, "... (max depth)")
 }
 
@@ -429,17 +429,17 @@ func TestTruncatedSlice(t *testing.T) {
 
 func TestCustomTruncatedSlice(t *testing.T) {
 	slice := make([]int, 3)
-	out := WithOptions(WithMaxItems(2)).DumpStr(slice)
+	out := NewDumper(WithMaxItems(2)).DumpStr(slice)
 	if !strings.Contains(out, "... (truncated)") {
 		t.Error("Expected slice to be truncated")
 	}
 
-	out = WithOptions(WithMaxItems(0)).DumpStr(slice)
+	out = NewDumper(WithMaxItems(0)).DumpStr(slice)
 	if !strings.Contains(out, "... (truncated)") {
 		t.Error("Expected slice to be truncated")
 	}
 
-	out = WithOptions(WithMaxItems(-1)).DumpStr(slice)
+	out = NewDumper(WithMaxItems(-1)).DumpStr(slice)
 	if strings.Contains(out, "... (truncated)") {
 		t.Error("Negative MaxItems option should not be applied")
 	}
@@ -455,17 +455,17 @@ func TestTruncatedString(t *testing.T) {
 
 func TestCustomTruncatedString(t *testing.T) {
 	s := strings.Repeat("x", 10)
-	out := WithOptions(WithMaxStringLen(9)).DumpStr(s)
+	out := NewDumper(WithMaxStringLen(9)).DumpStr(s)
 	if !strings.Contains(out, "…") {
 		t.Error("Expected long string to be truncated")
 	}
 
-	out = WithOptions(WithMaxStringLen(0)).DumpStr(s)
+	out = NewDumper(WithMaxStringLen(0)).DumpStr(s)
 	if !strings.Contains(out, "…") {
 		t.Error("Expected long string to be truncated")
 	}
 
-	out = WithOptions(WithMaxStringLen(-1)).DumpStr(s)
+	out = NewDumper(WithMaxStringLen(-1)).DumpStr(s)
 	if strings.Contains(out, "…") {
 		t.Error("Negative MaxStringLen option should not be applied")
 	}
@@ -482,7 +482,7 @@ func TestDefaultBranchFallback(t *testing.T) {
 	var v reflect.Value // zero reflect.Value
 	var sb strings.Builder
 	tw := tabwriter.NewWriter(&sb, 0, 0, 1, ' ', 0)
-	WithOptions().printValue(tw, v, 0, map[uintptr]bool{})
+	NewDumper().printValue(tw, v, 0, map[uintptr]bool{})
 	tw.Flush()
 	if !strings.Contains(sb.String(), "<invalid>") {
 		t.Error("Expected default fallback for invalid reflect.Value")
@@ -773,7 +773,7 @@ func TestPrintValue_ChanNilBranch_Hardforce(t *testing.T) {
 	assert.True(t, v.IsNil())
 	assert.Equal(t, reflect.Chan, v.Kind())
 
-	WithOptions().printValue(tw, v, 0, map[uintptr]bool{})
+	NewDumper().printValue(tw, v, 0, map[uintptr]bool{})
 	tw.Flush()
 
 	out := stripANSI(buf.String())

--- a/godump_test.go
+++ b/godump_test.go
@@ -215,7 +215,7 @@ func TestUnreadableFallback(t *testing.T) {
 	var ch chan int // nil typed value, not interface
 	rv := reflect.ValueOf(ch)
 
-	NewDumper().printValue(tw, rv, 0, map[uintptr]bool{})
+	defaultDumper.printValue(tw, rv, 0, map[uintptr]bool{})
 	tw.Flush()
 
 	output := stripANSI(b.String())
@@ -235,7 +235,7 @@ func TestUnreadableFieldFallback(t *testing.T) {
 	var sb strings.Builder
 	tw := tabwriter.NewWriter(&sb, 0, 0, 1, ' ', 0)
 
-	NewDumper().printValue(tw, v, 0, map[uintptr]bool{})
+	defaultDumper.printValue(tw, v, 0, map[uintptr]bool{})
 	tw.Flush()
 
 	out := stripANSI(sb.String())
@@ -288,7 +288,7 @@ func TestDefaultFallback_Unreadable(t *testing.T) {
 
 	var buf strings.Builder
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	NewDumper().printValue(tw, v, 0, map[uintptr]bool{})
+	defaultDumper.printValue(tw, v, 0, map[uintptr]bool{})
 	tw.Flush()
 
 	assert.Contains(t, buf.String(), "<invalid>")
@@ -299,7 +299,7 @@ func TestPrintValue_Uintptr(t *testing.T) {
 	val := uintptr(12345)
 	var buf strings.Builder
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	NewDumper().printValue(tw, reflect.ValueOf(val), 0, map[uintptr]bool{})
+	defaultDumper.printValue(tw, reflect.ValueOf(val), 0, map[uintptr]bool{})
 	tw.Flush()
 
 	assert.Contains(t, buf.String(), "12345")
@@ -311,7 +311,7 @@ func TestPrintValue_UnsafePointer(t *testing.T) {
 	up := unsafe.Pointer(&i)
 	var buf strings.Builder
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	NewDumper().printValue(tw, reflect.ValueOf(up), 0, map[uintptr]bool{})
+	defaultDumper.printValue(tw, reflect.ValueOf(up), 0, map[uintptr]bool{})
 	tw.Flush()
 
 	assert.Contains(t, buf.String(), "unsafe.Pointer")
@@ -321,7 +321,7 @@ func TestPrintValue_Func(t *testing.T) {
 	fn := func() {}
 	var buf strings.Builder
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	NewDumper().printValue(tw, reflect.ValueOf(fn), 0, map[uintptr]bool{})
+	defaultDumper.printValue(tw, reflect.ValueOf(fn), 0, map[uintptr]bool{})
 	tw.Flush()
 
 	assert.Contains(t, buf.String(), "func(...) {...}")
@@ -482,7 +482,7 @@ func TestDefaultBranchFallback(t *testing.T) {
 	var v reflect.Value // zero reflect.Value
 	var sb strings.Builder
 	tw := tabwriter.NewWriter(&sb, 0, 0, 1, ' ', 0)
-	NewDumper().printValue(tw, v, 0, map[uintptr]bool{})
+	defaultDumper.printValue(tw, v, 0, map[uintptr]bool{})
 	tw.Flush()
 	if !strings.Contains(sb.String(), "<invalid>") {
 		t.Error("Expected default fallback for invalid reflect.Value")
@@ -773,7 +773,7 @@ func TestPrintValue_ChanNilBranch_Hardforce(t *testing.T) {
 	assert.True(t, v.IsNil())
 	assert.Equal(t, reflect.Chan, v.Kind())
 
-	NewDumper().printValue(tw, v, 0, map[uintptr]bool{})
+	defaultDumper.printValue(tw, v, 0, map[uintptr]bool{})
 	tw.Flush()
 
 	out := stripANSI(buf.String())

--- a/godump_test.go
+++ b/godump_test.go
@@ -854,6 +854,40 @@ func TestFdump_WritesToWriter(t *testing.T) {
 	}
 }
 
+func TestDumpWithCustomWriter(t *testing.T) {
+	var buf strings.Builder
+
+	type Inner struct {
+		Field string
+	}
+	type Outer struct {
+		InnerField Inner
+		Number     int
+	}
+
+	val := Outer{
+		InnerField: Inner{Field: "hello"},
+		Number:     42,
+	}
+
+	NewDumper(WithWriter(&buf)).Dump(val)
+
+	out := buf.String()
+
+	if !strings.Contains(out, "Outer") {
+		t.Errorf("expected output to contain type name 'Outer', got: %s", out)
+	}
+	if !strings.Contains(out, "InnerField") || !strings.Contains(out, "hello") {
+		t.Errorf("expected nested struct and field to appear, got: %s", out)
+	}
+	if !strings.Contains(out, "Number") || !strings.Contains(out, "42") {
+		t.Errorf("expected field 'Number' with value '42', got: %s", out)
+	}
+	if !strings.Contains(out, "<#dump //") {
+		t.Errorf("expected dump header with file and line, got: %s", out)
+	}
+}
+
 // TestHexDumpRendering checks that the hex dump output is rendered correctly.
 func TestHexDumpRendering(t *testing.T) {
 	input := []byte(`{"error":"kek","last_error":"not implemented","lol":"ok"}`)


### PR DESCRIPTION
## Add support for customizable dump options

This PR introduces the ability for users to customize a few key parameters of the dumper:

- maxItems
- maxDepth
- maxStringLen

The main goal is to allow usage like:

```go
d := godump.NewDumper(
	godump.WithMaxDepth(15),          // default: 15
	godump.WithMaxItems(100),         // default: 100
	godump.WithMaxStringLen(100000),  // default: 100000
	godump.WithWriter(os.Stdout),     // default: os.Stdout
)
```

I tried to design the API in a way that is flexible, ergonomic, and backward-compatible. While it might look a bit over-engineered, this approach seemed like the cleanest way to introduce configuration without breaking existing usage or overloading the core functions with too many parameters.

Known trade-offs / open questions:

- Some duplication in GoDoc might be hard to avoid for each option.
- There could be a slight performance impact due to the added indirection (should be negligible in most use cases, but worth pointing out).

Feedback is very welcome — especially if there's a simpler or more idiomatic way to approach this!