### PR TITLE
fix: avoid duplicate fields in Dump when using embedded (anonymous) structs

### DIFF
--- a/godump.go
+++ b/godump.go
@@ -299,9 +299,11 @@ func printValue(tw *tabwriter.Writer, v reflect.Value, indent int, visited map[u
 		t := v.Type()
 		fmt.Fprintf(tw, "%s ", colorize(colorGray, "#"+t.String()))
 		fmt.Fprintln(tw)
-		visibleFields := reflect.VisibleFields(t)
-		for _, field := range visibleFields {
-			fieldVal := v.FieldByIndex(field.Index)
+
+		for i := range t.NumField() {
+			field := t.Field(i)
+			fieldVal := v.Field(i)
+
 			symbol := "+"
 			if field.PkgPath != "" {
 				symbol = "-"

--- a/godump_test.go
+++ b/godump_test.go
@@ -111,11 +111,12 @@ func TestEmbeddedAnonymousStruct(t *testing.T) {
 
 	out := stripANSI(DumpStr(Derived{Base: Base{ID: 456}, Name: "Test"}))
 
-	assert.Contains(t, out, "+Base")
-	assert.Contains(t, out, "+ID")
-	assert.Contains(t, out, "456")
-	assert.Contains(t, out, "+Name")
-	assert.Contains(t, out, "\"Test\"")
+	assert.Contains(t, out, `#godump.Derived 
+  +Base => #godump.Base 
+    +ID => 456
+  }
+  +Name => "Test"
+}`)
 }
 
 func TestControlCharsEscaped(t *testing.T) {

--- a/godump_test.go
+++ b/godump_test.go
@@ -100,6 +100,24 @@ func TestAnonymousStruct(t *testing.T) {
 	assert.Contains(t, out, "123")
 }
 
+func TestEmbeddedAnonymousStruct(t *testing.T) {
+	type Base struct {
+		ID int
+	}
+	type Derived struct {
+		Base
+		Name string
+	}
+
+	out := stripANSI(DumpStr(Derived{Base: Base{ID: 456}, Name: "Test"}))
+
+	assert.Contains(t, out, "+Base")
+	assert.Contains(t, out, "+ID")
+	assert.Contains(t, out, "456")
+	assert.Contains(t, out, "+Name")
+	assert.Contains(t, out, "\"Test\"")
+}
+
 func TestControlCharsEscaped(t *testing.T) {
 	s := "line1\nline2\tok"
 	out := stripANSI(DumpStr(s))


### PR DESCRIPTION
fix issue https://github.com/goforj/godump/issues/21

**Before:**

<img width="378" alt="image" src="https://github.com/user-attachments/assets/1b8011a0-c3b8-4c02-b4d5-4e0356c28792" />


**After:**
<img width="378" alt="image" src="https://github.com/user-attachments/assets/7e1af9c4-63e7-4896-94b1-0a4e95b49ac1" />
