### PR TITLE
fix: correct colorizer reference in DumpHTML function

### DIFF
--- a/godump.go
+++ b/godump.go
@@ -95,7 +95,7 @@ func DumpStr(vs ...any) string {
 
 // DumpHTML dumps the values as HTML with colorized output.
 func DumpHTML(vs ...any) string {
-	prevColorize := ansiColorize
+	prevColorize := colorize
 	prevEnable := enableColor
 	defer func() {
 		colorize = prevColorize


### PR DESCRIPTION
This PR fixes a bug in the DumpHTML function where it was always restoring the colorizer to ansiColorize regardless of what colorizer was being used before the function call.