### PR TITLE
chore: remove unused secret struct

### DIFF
--- a/godump_test.go
+++ b/godump_test.go
@@ -206,11 +206,6 @@ func TestHtmlColorizeUnknown(t *testing.T) {
 	assert.Contains(t, out, "test")
 }
 
-// package-level type + method
-type secret struct{}
-
-func (secret) hidden() {}
-
 func TestUnreadableFallback(t *testing.T) {
 	var b strings.Builder
 	tw := tabwriter.NewWriter(&b, 0, 0, 1, ' ', 0)


### PR DESCRIPTION
This struct was added with af1899eea57630088828d27bfd75cc504c43d8b7,
but it had never been used.

Later, secretstring type was added with c483de2d, and this one is used.

This commit removes the unused struct.
