### PR TITLE
fix: use base16 terminal colors

### DIFF
--- a/godump.go
+++ b/godump.go
@@ -15,16 +15,14 @@ import (
 )
 
 const (
-	colorReset   = "\033[0m"
-	colorGray    = "\033[90m"
-	colorYellow  = "\033[33m"
-	colorLime    = "\033[38;5;113m"
-	colorCyan    = "\033[38;5;38m"
-	colorNote    = "\033[38;5;38m"
-	colorRef     = "\033[38;5;247m"
-	colorMeta    = "\033[38;5;170m"
-	colorDefault = "\033[38;5;208m"
-	indentWidth  = 2
+	colorReset  = "\033[0m"
+	colorGray   = "\033[90m"
+	colorYellow = "\033[93m"
+	colorLime   = "\033[92m"
+	colorCyan   = "\033[96m"
+	colorRef    = "\033[94m"
+	colorMeta   = "\033[95m"
+	indentWidth = 2
 )
 
 // Default configuration values for the Dumper.
@@ -62,13 +60,11 @@ func ansiColorize(code, str string) string {
 
 // htmlColorMap maps color codes to HTML colors.
 var htmlColorMap = map[string]string{
-	colorGray:    "#999",
-	colorYellow:  "#ffb400",
-	colorLime:    "#80ff80",
-	colorNote:    "#40c0ff",
-	colorRef:     "#aaa",
-	colorMeta:    "#d087d0",
-	colorDefault: "#ff7f00",
+	colorGray:   "#999",
+	colorYellow: "#ffb400",
+	colorLime:   "#80ff80",
+	colorRef:    "#aaa",
+	colorMeta:   "#d087d0",
 }
 
 // htmlColorize colorizes the string using HTML span tags.


### PR DESCRIPTION
Hi! Thanks for the great library, my little proposal here.

Instead of hardcoding colors it may be better to use base16 terminal colors, which are usually controlled by the user's theme.

Hardcoded colors can lead to poor contrast, especially on light themes, where the text may blend into the background:
<details>
<summary>Examples of low text contrast on some popular light themes(After/Before)</summary>
<img src="https://github.com/user-attachments/assets/4d0f69a0-ac6e-4e9c-95b7-1ffb2d54ac22" />
<img src="https://github.com/user-attachments/assets/53d46a06-6913-477a-ba0c-cdef80b88d99" />
</details>

Even when contrast is acceptable, hardcoded colors may clash with the theme’s saturation or tone. In contrast, terminal-defined colors tend to blend better with the overall look and feel:
<details>
<summary>Better theme integration</summary>
<img src="https://github.com/user-attachments/assets/ae4881b8-3724-43d9-8ea9-ad8a104f8d18" />
</details>

Let me know what you think - happy to iterate if needed!