### PR TITLE
feat: Add support to disable methods

### DIFF
--- a/godump.go
+++ b/godump.go
@@ -29,11 +29,12 @@ const (
 
 // Default configuration values for the Dumper.
 const (
-	defaultMaxDepth      = 15
-	defaultMaxItems      = 100
-	defaultMaxStringLen  = 100000
-	defaultMaxStackDepth = 10
-	initialCallerSkip    = 2
+	defaultDisableMethods = false
+	defaultMaxDepth       = 15
+	defaultMaxItems       = 100
+	defaultMaxStringLen   = 100000
+	defaultMaxStackDepth  = 10
+	initialCallerSkip     = 2
 )
 
 // defaultDumper is the default Dumper instance used by Dump and DumpStr functions.
@@ -86,6 +87,7 @@ type Dumper struct {
 	maxStringLen       int
 	writer             io.Writer
 	skippedStackFrames int
+	disableMethods     bool
 
 	// callerFn is used to get the caller information.
 	// It defaults to [runtime.Caller], it is here to be overridden for testing purposes.
@@ -149,15 +151,26 @@ func WithSkipStackFrames(n int) Option {
 	}
 }
 
+// WithDisableMethods will determine if interface methods such as the stringer
+// interface should be called for types implementing it. This can be useful if
+// you want to see the internals of types implementing a method.
+func WithDisableMethods(b bool) Option {
+	return func(d *Dumper) *Dumper {
+		d.disableMethods = b
+		return d
+	}
+}
+
 // NewDumper creates a new Dumper with the given options applied.
 // Defaults are used for any setting not overridden.
 func NewDumper(opts ...Option) *Dumper {
 	d := &Dumper{
-		maxDepth:     defaultMaxDepth,
-		maxItems:     defaultMaxItems,
-		maxStringLen: defaultMaxStringLen,
-		writer:       os.Stdout,
-		callerFn:     runtime.Caller,
+		maxDepth:       defaultMaxDepth,
+		maxItems:       defaultMaxItems,
+		maxStringLen:   defaultMaxStringLen,
+		disableMethods: defaultDisableMethods,
+		writer:         os.Stdout,
+		callerFn:       runtime.Caller,
 	}
 	for _, opt := range opts {
 		d = opt(d)
@@ -404,7 +417,7 @@ func (d *Dumper) printValue(tw *tabwriter.Writer, v reflect.Value, indent int, v
 		return
 	}
 
-	if s := asStringer(v); s != "" {
+	if s := d.asStringer(v); s != "" {
 		fmt.Fprint(tw, s)
 		return
 	}
@@ -455,7 +468,7 @@ func (d *Dumper) printValue(tw *tabwriter.Writer, v reflect.Value, indent int, v
 			}
 			indentPrint(tw, indent+1, colorize(colorYellow, symbol)+field.Name)
 			fmt.Fprint(tw, "	=> ")
-			if s := asStringer(fieldVal); s != "" {
+			if s := d.asStringer(fieldVal); s != "" {
 				fmt.Fprint(tw, s)
 			} else {
 				d.printValue(tw, fieldVal, indent+1, visited)
@@ -535,7 +548,11 @@ func (d *Dumper) printValue(tw *tabwriter.Writer, v reflect.Value, indent int, v
 }
 
 // asStringer checks if the value implements fmt.Stringer and returns its string representation.
-func asStringer(v reflect.Value) string {
+func (d *Dumper) asStringer(v reflect.Value) string {
+	if d.disableMethods {
+		return ""
+	}
+
 	val := v
 	if !val.CanInterface() {
 		val = forceExported(val)

--- a/godump_test.go
+++ b/godump_test.go
@@ -653,7 +653,6 @@ func TestTheKitchenSink(t *testing.T) {
 	// Ensure no panic occurred and a sane dump was produced
 	assert.Contains(t, out, "#")          // loosest
 	assert.Contains(t, out, "Everything") // middle-ground
-
 }
 
 func TestAnsiColorize_Disabled(t *testing.T) {
@@ -738,7 +737,7 @@ func TestAsStringer_ForceExported(t *testing.T) {
 	v := reflect.ValueOf(h).Elem().FieldByName("secret") // now v.CanAddr() is true, but v.CanInterface() is false
 
 	assert.False(t, v.CanInterface(), "field must not be interfaceable")
-	str := asStringer(v)
+	str := defaultDumper.asStringer(v)
 
 	assert.Contains(t, str, "👻 hidden stringer")
 }
@@ -1052,5 +1051,26 @@ func TestDumpJSON(t *testing.T) {
 
 		assert.Equal(t, []any{"foo", float64(123), true}, got)
 	})
+}
 
+type hasStringer struct {
+	internal string
+}
+
+func (hasStringer) String() string {
+	return "stringer value"
+}
+
+func TestDisableMethods(t *testing.T) {
+	data := hasStringer{
+		internal: "internal value",
+	}
+
+	d := NewDumper(WithDisableMethods(true))
+	v := d.DumpStr(data)
+	require.Contains(t, v, "internal value")
+
+	d = NewDumper()
+	v = d.DumpStr(data)
+	require.Contains(t, v, "stringer value")
 }


### PR DESCRIPTION
Currently `godump` always uses the stringer interface if defined. This is not always desirable if you want to check the internals of a type.

This adds a feature with the same name used for [`spew`][spew] (`DisableMethods`) which can be set to true to disable this feature.

[spew]: https://github.com/davecgh/go-spew/blob/8991bc29aa16c548c550c7ff78260e27b9ab7c73/spew/config.go#L52-L54