### PR TITLE
feat: Add support to always show types.

### DIFF
--- a/godump.go
+++ b/godump.go
@@ -33,6 +33,7 @@ const (
 	defaultMaxItems      = 100
 	defaultMaxStringLen  = 100000
 	defaultMaxStackDepth = 10
+	defaultShowAllTypes  = false
 	initialCallerSkip    = 2
 )
 
@@ -84,6 +85,7 @@ type Dumper struct {
 	maxDepth           int
 	maxItems           int
 	maxStringLen       int
+	showAllTypes       bool
 	writer             io.Writer
 	skippedStackFrames int
 
@@ -149,6 +151,14 @@ func WithSkipStackFrames(n int) Option {
 	}
 }
 
+// WithShowAllTypes enables or disables always showing types for primitives.
+func WithShowAllTypes(b bool) Option {
+	return func(d *Dumper) *Dumper {
+		d.showAllTypes = b
+		return d
+	}
+}
+
 // NewDumper creates a new Dumper with the given options applied.
 // Defaults are used for any setting not overridden.
 func NewDumper(opts ...Option) *Dumper {
@@ -156,6 +166,7 @@ func NewDumper(opts ...Option) *Dumper {
 		maxDepth:     defaultMaxDepth,
 		maxItems:     defaultMaxItems,
 		maxStringLen: defaultMaxStringLen,
+		showAllTypes: defaultShowAllTypes,
 		writer:       os.Stdout,
 		callerFn:     runtime.Caller,
 	}
@@ -469,7 +480,17 @@ func (d *Dumper) printValue(tw *tabwriter.Writer, v reflect.Value, indent int, v
 	case reflect.UnsafePointer:
 		fmt.Fprint(tw, colorize(colorGray, fmt.Sprintf("unsafe.Pointer(%#x)", v.Pointer())))
 	case reflect.Map:
-		fmt.Fprintln(tw, "{")
+		if d.showAllTypes {
+			keyType := v.Type().Key().Kind().String()
+			valType := v.Type().Elem().Kind().String()
+			keyValType := fmt.Sprintf("#map[%s]%s", keyType, valType)
+
+			fmt.Fprintf(tw, "{ %s", colorize(colorGray, keyValType))
+			fmt.Fprintln(tw)
+		} else {
+			fmt.Fprintln(tw, "{")
+		}
+
 		keys := v.MapKeys()
 		for i, key := range keys {
 			if i >= d.maxItems {
@@ -496,7 +517,13 @@ func (d *Dumper) printValue(tw *tabwriter.Writer, v reflect.Value, indent int, v
 		}
 
 		// Default rendering for other slices/arrays
-		fmt.Fprintln(tw, "[")
+		if d.showAllTypes {
+			fmt.Fprintf(tw, "[ %s", colorize(colorGray, "#[]"+v.Type().Elem().Kind().String()))
+			fmt.Fprintln(tw)
+		} else {
+			fmt.Fprintln(tw, "[")
+		}
+
 		for i := range v.Len() {
 			if i >= d.maxItems {
 				indentPrint(tw, indent+1, colorize(colorGray, "... (truncated)\n"))
@@ -515,18 +542,33 @@ func (d *Dumper) printValue(tw *tabwriter.Writer, v reflect.Value, indent int, v
 			str = string(runes[:d.maxStringLen]) + "…"
 		}
 		fmt.Fprint(tw, colorize(colorYellow, `"`)+colorize(colorLime, str)+colorize(colorYellow, `"`))
+		if d.showAllTypes {
+			fmt.Fprint(tw, colorize(colorGray, " #"+v.Type().String()))
+		}
 	case reflect.Bool:
 		if v.Bool() {
 			fmt.Fprint(tw, colorize(colorYellow, "true"))
 		} else {
 			fmt.Fprint(tw, colorize(colorGray, "false"))
 		}
+		if d.showAllTypes {
+			fmt.Fprint(tw, colorize(colorGray, " #"+v.Type().String()))
+		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		fmt.Fprint(tw, colorize(colorCyan, fmt.Sprint(v.Int())))
+		if d.showAllTypes {
+			fmt.Fprint(tw, colorize(colorGray, " #"+v.Type().String()))
+		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		fmt.Fprint(tw, colorize(colorCyan, fmt.Sprint(v.Uint())))
+		if d.showAllTypes {
+			fmt.Fprint(tw, colorize(colorGray, " #"+v.Type().String()))
+		}
 	case reflect.Float32, reflect.Float64:
 		fmt.Fprint(tw, colorize(colorCyan, fmt.Sprintf("%f", v.Float())))
+		if d.showAllTypes {
+			fmt.Fprint(tw, colorize(colorGray, " #"+v.Type().String()))
+		}
 	case reflect.Func:
 		fmt.Fprint(tw, colorize(colorGray, v.Type().String()))
 	default:

--- a/godump_test.go
+++ b/godump_test.go
@@ -653,7 +653,6 @@ func TestTheKitchenSink(t *testing.T) {
 	// Ensure no panic occurred and a sane dump was produced
 	assert.Contains(t, out, "#")          // loosest
 	assert.Contains(t, out, "Everything") // middle-ground
-
 }
 
 func TestAnsiColorize_Disabled(t *testing.T) {
@@ -1052,5 +1051,55 @@ func TestDumpJSON(t *testing.T) {
 
 		assert.Equal(t, []any{"foo", float64(123), true}, got)
 	})
+}
 
+func TestShowAllTypesFlag(t *testing.T) {
+	type StrAlias string
+
+	type ShowTypes struct {
+		SignedNumber   int
+		UnsignedNumber uint
+		Float          float64
+		Str            string
+		Alias          StrAlias
+		Boolean        bool
+		Time           time.Time
+		Slice          []int
+		KeyVal         map[string]string
+	}
+
+	v := ShowTypes{
+		SignedNumber:   -10,
+		UnsignedNumber: 10,
+		Float:          10.10,
+		Str:            "Hello, World",
+		Alias:          StrAlias("Hello, World"),
+		Boolean:        true,
+		Time:           time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
+		Slice:          []int{1, 2, 3},
+		KeyVal: map[string]string{
+			"k1": "v1",
+			"k2": "v2",
+		},
+	}
+
+	out := stripANSI(NewDumper().DumpStr(v))
+	assert.NotContains(t, out, "#int")
+	assert.NotContains(t, out, "#uint")
+	assert.NotContains(t, out, "#float64")
+	assert.NotContains(t, out, "#string")
+	assert.NotContains(t, out, "StrAlias")
+	assert.NotContains(t, out, "#bool")
+	assert.NotContains(t, out, "#[]int")
+	assert.NotContains(t, out, "#map[string]string")
+
+	out = stripANSI(NewDumper(WithShowAllTypes(true)).DumpStr(v))
+	assert.Contains(t, out, "#int")
+	assert.Contains(t, out, "#uint")
+	assert.Contains(t, out, "#float64")
+	assert.Contains(t, out, "#string")
+	assert.Contains(t, out, "StrAlias")
+	assert.Contains(t, out, "#bool")
+	assert.Contains(t, out, "#[]int")
+	assert.Contains(t, out, "#map[string]string")
 }


### PR DESCRIPTION
Add support to always show types, even for built-in types such as `string`, `int`, `int32` etc. This will also show type for type aliases of such types.

---

I find myself quite often wanting to know the type even for built-in values, e.g. the exact type of integer or the aliased type for a type alias. I also miss this when dumping types such as `[]any` or `map[string]any`.

I don't know if this should actually be feature gated with a feature flag like this or if I should've filed an issue and discussed this as a potential default first instead, but this was simple enough to test so here's just an example/RFC on how to let the user print _all_ types.

### Before (current)

<img width="750" height="483" alt="image" src="https://github.com/user-attachments/assets/fe7fe240-df3f-46d6-b0ac-28c217709d9e" />

### After (using `WithShowAllTypes`)

<img width="755" height="479" alt="image" src="https://github.com/user-attachments/assets/aacdc7df-7fe2-4ce3-b22a-dea60ebc8d77" />