### PR TITLE
feat: support up to Go 1.18

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -10,13 +10,29 @@ on:
     - cron: "0 3 * * 0"
 
 jobs:
+  go-versions:
+    name: Lookup Go versions
+    runs-on: ubuntu-latest
+    outputs:
+      go-mod-version: ${{ steps.versions.outputs.go-mod-version }}
+      latest: ${{ steps.versions.outputs.latest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: arnested/go-version-action@v1
+        id: versions
+        with:
+          unstable: true # this includes the future -rc versions
+
   go-compatibility:
+    needs: go-versions
     name: Go ${{ matrix.go-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: ["1.23", "oldstable", "stable"]
+        go-version: ["${{ needs.go-versions.outputs.go-mod-version }}", "oldstable", "stable"]
 
     steps:
       - name: Checkout
@@ -26,6 +42,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
 
       - name: Run tests
         run: go test ./... -v -race

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Install dependencies
         run: go mod tidy
 
-      - name: Check code modernization
-        run: make modernize-check
-
       - name: Run tests
         run: go test ./... -v
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "stable"
 
       - name: Install dependencies
         run: go mod tidy

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://pkg.go.dev/github.com/goforj/godump"><img src="https://pkg.go.dev/badge/github.com/goforj/godump.svg" alt="Go Reference"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
     <a href="https://github.com/goforj/godump/actions"><img src="https://github.com/goforj/godump/actions/workflows/test.yml/badge.svg" alt="Go Test"></a>
-    <a href="https://golang.org"><img src="https://img.shields.io/badge/go-1.23+-blue?logo=go" alt="Go version"></a>
+    <a href="https://golang.org"><img src="https://img.shields.io/badge/go-1.18+-blue?logo=go" alt="Go version"></a>
     <img src="https://img.shields.io/github/v/tag/goforj/godump?label=version&sort=semver" alt="Latest tag">
     <a href="https://goreportcard.com/report/github.com/goforj/godump"><img src="https://goreportcard.com/badge/github.com/goforj/godump" alt="Go Report Card"></a>
     <a href="https://codecov.io/gh/goforj/godump" ><img src="https://codecov.io/gh/goforj/godump/graph/badge.svg?token=ULUTXL03XC"/></a>

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goforj/godump
 
-go 1.23
+go 1.18
 
 require github.com/stretchr/testify v1.10.0
 

--- a/godump.go
+++ b/godump.go
@@ -340,7 +340,11 @@ func (d *Dumper) formatByteSliceAsHexDump(b []byte, indent int) string {
 	sb.WriteString(fmt.Sprintf("([]uint8) (len=%d cap=%d) {\n", len(b), cap(b)))
 
 	for i := 0; i < len(b); i += lineLen {
-		end := min(i+lineLen, len(b))
+
+		end := i + lineLen
+		if end > len(b) {
+			end = len(b)
+		}
 		line := b[i:end]
 
 		visibleLen := 0
@@ -352,7 +356,7 @@ func (d *Dumper) formatByteSliceAsHexDump(b []byte, indent int) string {
 		visibleLen += len(offsetStr)
 
 		// Hex bytes
-		for j := range lineLen {
+		for j := 0; j < lineLen; j++ {
 			var hexStr string
 			if j < len(line) {
 				hexStr = fmt.Sprintf("%02x ", line[j])
@@ -367,7 +371,10 @@ func (d *Dumper) formatByteSliceAsHexDump(b []byte, indent int) string {
 		}
 
 		// Padding before ASCII
-		padding := max(1, asciiStartCol-visibleLen)
+		padding := asciiStartCol - visibleLen
+		if padding < 1 {
+			padding = 1
+		}
 		sb.WriteString(strings.Repeat(" ", padding))
 
 		// ASCII section
@@ -454,7 +461,7 @@ func (d *Dumper) printValue(w io.Writer, v reflect.Value, indent int, visited ma
 		fmt.Fprintf(w, "%s {", d.colorize(colorGray, "#"+t.String()))
 		fmt.Fprintln(w)
 
-		for i := range t.NumField() {
+		for i := 0; i < t.NumField(); i++ {
 			field := t.Field(i)
 			fieldVal := v.Field(i)
 
@@ -507,7 +514,7 @@ func (d *Dumper) printValue(w io.Writer, v reflect.Value, indent int, visited ma
 
 		// Default rendering for other slices/arrays
 		fmt.Fprintln(w, "[")
-		for i := range v.Len() {
+		for i := 0; i < v.Len(); i++ {
 			if i >= d.maxItems {
 				indentPrint(w, indent+1, d.colorize(colorGray, "... (truncated)\n"))
 				break

--- a/godump_test.go
+++ b/godump_test.go
@@ -80,7 +80,7 @@ func TestMaxDepth(t *testing.T) {
 	}
 	n := &Node{}
 	curr := n
-	for range 20 {
+	for i := 0; i < 20; i++ {
 		curr.Child = &Node{}
 		curr = curr.Child
 	}
@@ -341,7 +341,7 @@ func TestMaxDepthTruncation(t *testing.T) {
 	}
 	root := &Node{}
 	curr := root
-	for range 20 {
+	for i := 0; i < 20; i++ {
 		curr.Next = &Node{}
 		curr = curr.Next
 	}
@@ -356,7 +356,7 @@ func TestCustomMaxDepthTruncation(t *testing.T) {
 	}
 	root := &Node{}
 	curr := root
-	for range 3 {
+	for i := 0; i < 3; i++ {
 		curr.Next = &Node{}
 		curr = curr.Next
 	}
@@ -373,7 +373,7 @@ func TestCustomMaxDepthTruncation(t *testing.T) {
 
 func TestMapTruncation(t *testing.T) {
 	largeMap := map[int]int{}
-	for i := range 200 {
+	for i := 0; i < 200; i++ {
 		largeMap[i] = i
 	}
 	out := dumpStrT(t, largeMap)


### PR DESCRIPTION
The code can be used with old Go versions.

The CI will also run tests for Go 1.18 and latest -rc versions.

Fixed #42