### PR TITLE
fix: max depth issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://goreportcard.com/report/github.com/goforj/godump"><img src="https://goreportcard.com/badge/github.com/goforj/godump" alt="Go Report Card"></a>
     <a href="https://codecov.io/gh/goforj/godump" ><img src="https://codecov.io/gh/goforj/godump/graph/badge.svg?token=ULUTXL03XC"/></a>
 <!-- test-count:embed:start -->
-    <img src="https://img.shields.io/badge/tests-143-brightgreen" alt="Tests">
+    <img src="https://img.shields.io/badge/tests-156-brightgreen" alt="Tests">
 <!-- test-count:embed:end -->
     <a href="https://github.com/avelino/awesome-go?tab=readme-ov-file#parsersencodersdecoders"><img src="https://awesome.re/mentioned-badge-flat.svg" alt="Mentioned in Awesome Go"></a>
 </p>
@@ -583,9 +583,9 @@ Param n must be 0 or greater or this will be ignored, and default MaxDepth will 
 v := map[string]map[string]int{"a": {"b": 1}}
 d := godump.NewDumper(godump.WithMaxDepth(1))
 d.Dump(v)
-// #map[string]int {
+// #map[string]map[string]int {
 //   a => #map[string]int {
-//     b => ... (max depth)
+//     b => 1 #int
 //   }
 // }
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://goreportcard.com/report/github.com/goforj/godump"><img src="https://goreportcard.com/badge/github.com/goforj/godump" alt="Go Report Card"></a>
     <a href="https://codecov.io/gh/goforj/godump" ><img src="https://codecov.io/gh/goforj/godump/graph/badge.svg?token=ULUTXL03XC"/></a>
 <!-- test-count:embed:start -->
-    <img src="https://img.shields.io/badge/tests-156-brightgreen" alt="Tests">
+    <img src="https://img.shields.io/badge/tests-162-brightgreen" alt="Tests">
 <!-- test-count:embed:end -->
     <a href="https://github.com/avelino/awesome-go?tab=readme-ov-file#parsersencodersdecoders"><img src="https://awesome.re/mentioned-badge-flat.svg" alt="Mentioned in Awesome Go"></a>
 </p>

--- a/examples/withmaxdepth/main.go
+++ b/examples/withmaxdepth/main.go
@@ -14,9 +14,9 @@ func main() {
 	v := map[string]map[string]int{"a": {"b": 1}}
 	d := godump.NewDumper(godump.WithMaxDepth(1))
 	d.Dump(v)
-	// #map[string]int {
+	// #map[string]map[string]int {
 	//   a => #map[string]int {
-	//     b => ... (max depth)
+	//     b => 1 #int
 	//   }
 	// }
 }

--- a/godump.go
+++ b/godump.go
@@ -1249,25 +1249,26 @@ func complexBaseKind(v reflect.Value) (reflect.Kind, bool) {
 		return 0, false
 	}
 
-	for v.Kind() == reflect.Interface {
-		if v.IsNil() {
-			return 0, false
+	for {
+		switch v.Kind() {
+		case reflect.Interface:
+			if v.IsNil() {
+				return 0, false
+			}
+			v = v.Elem()
+		case reflect.Ptr:
+			if v.IsNil() {
+				return 0, false
+			}
+			v = v.Elem()
+		default:
+			switch v.Kind() {
+			case reflect.Struct, reflect.Map, reflect.Slice, reflect.Array:
+				return v.Kind(), true
+			default:
+				return 0, false
+			}
 		}
-		v = v.Elem()
-	}
-
-	for v.Kind() == reflect.Ptr {
-		if v.IsNil() {
-			return 0, false
-		}
-		v = v.Elem()
-	}
-
-	switch v.Kind() {
-	case reflect.Struct, reflect.Map, reflect.Slice, reflect.Array:
-		return v.Kind(), true
-	default:
-		return 0, false
 	}
 }
 

--- a/godump.go
+++ b/godump.go
@@ -1164,6 +1164,7 @@ func detectColor() bool {
 	return true
 }
 
+// newColorizer picks the appropriate colorizer based on environment overrides.
 func newColorizer() Colorizer {
 	if detectColor() {
 		return colorizeANSI
@@ -1171,6 +1172,7 @@ func newColorizer() Colorizer {
 	return colorizeUnstyled
 }
 
+// contains reports whether target exists in the candidates slice.
 func contains(candidates []reflect.Kind, target reflect.Kind) bool {
 	for _, candidate := range candidates {
 		if candidate == target {
@@ -1181,6 +1183,7 @@ func contains(candidates []reflect.Kind, target reflect.Kind) bool {
 	return false
 }
 
+// shouldIncludeField returns true when the field survives include/exclude filtering (include takes precedence).
 func (d *Dumper) shouldIncludeField(name string) bool {
 	if len(d.includeFields) > 0 && !d.matchesAny(name, d.includeFields, FieldMatchExact) {
 		return false
@@ -1188,10 +1191,12 @@ func (d *Dumper) shouldIncludeField(name string) bool {
 	return !d.matchesAny(name, d.excludeFields, d.fieldMatchMode)
 }
 
+// shouldRedactField reports whether the field should be replaced with the redacted placeholder.
 func (d *Dumper) shouldRedactField(name string) bool {
 	return d.matchesAny(name, d.redactFields, d.redactMatchMode)
 }
 
+// matchesAny checks whether name matches any of the candidates using the provided mode.
 func (d *Dumper) matchesAny(name string, candidates []string, mode FieldMatchMode) bool {
 	if len(candidates) == 0 {
 		return false
@@ -1232,11 +1237,13 @@ func (d *Dumper) redactedValue(v reflect.Value) string {
 	return d.colorize(colorRed, "<redacted>") + d.colorize(colorGray, " #"+typeStr)
 }
 
+// isComplexValue reports whether v unwraps to a struct/map/slice/array.
 func isComplexValue(v reflect.Value) bool {
 	_, ok := complexBaseKind(v)
 	return ok
 }
 
+// complexBaseKind unwraps interfaces/pointers, rejects nil, and returns the underlying complex kind if present.
 func complexBaseKind(v reflect.Value) (reflect.Kind, bool) {
 	if !v.IsValid() {
 		return 0, false
@@ -1264,15 +1271,17 @@ func complexBaseKind(v reflect.Value) (reflect.Kind, bool) {
 	}
 }
 
+// shouldTruncateAtDepth determines whether we should print a truncation placeholder at this depth for complex values.
 func shouldTruncateAtDepth(v reflect.Value, indent, maxDepth int) bool {
-	if indent > maxDepth && isComplexValue(v) {
-		return true
-	}
 	if indent < maxDepth {
 		return false
 	}
 
 	kind, ok := complexBaseKind(v)
+	if indent > maxDepth {
+		return ok
+	}
+
 	if !ok {
 		return false
 	}

--- a/godump_test.go
+++ b/godump_test.go
@@ -1593,3 +1593,60 @@ func TestDumpStr_Coverage(t *testing.T) {
 		t.Fatalf("expected DumpStr to include value, got: %s", out)
 	}
 }
+
+func TestShouldTruncateAtDepth(t *testing.T) {
+	type sample struct {
+		Value string
+	}
+
+	tests := []struct {
+		name     string
+		value    reflect.Value
+		indent   int
+		maxDepth int
+		want     bool
+	}{
+		{
+			name:     "indent below max does not truncate",
+			value:    reflect.ValueOf(map[int]string{}),
+			indent:   0,
+			maxDepth: 1,
+			want:     false,
+		},
+		{
+			name:     "indent above max truncates complex values",
+			value:    reflect.ValueOf(sample{}),
+			indent:   2,
+			maxDepth: 1,
+			want:     true,
+		},
+		{
+			name:     "indent equals max truncates collections",
+			value:    reflect.ValueOf([]int{1, 2}),
+			indent:   1,
+			maxDepth: 1,
+			want:     true,
+		},
+		{
+			name:     "indent equals max allows structs",
+			value:    reflect.ValueOf(sample{}),
+			indent:   1,
+			maxDepth: 1,
+			want:     false,
+		},
+		{
+			name:     "indent equals max allows scalars",
+			value:    reflect.ValueOf(42),
+			indent:   1,
+			maxDepth: 1,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldTruncateAtDepth(tt.value, tt.indent, tt.maxDepth)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/godump_test.go
+++ b/godump_test.go
@@ -122,6 +122,260 @@ func TestMaxDepth(t *testing.T) {
 	assert.Contains(t, out, "... (max depth)")
 }
 
+func TestMaxDepthAllowsScalarValues(t *testing.T) {
+	type Inner struct {
+		ID   int
+		Name string
+	}
+	type Outer struct {
+		Inner Inner
+	}
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		Inner: Inner{
+			ID:   101,
+			Name: "alpha",
+		},
+	})
+
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "101")
+	assert.Contains(t, out, `"alpha"`)
+	assert.NotContains(t, out, "... (max depth)")
+}
+
+func TestMaxDepthBlocksStringerStructs(t *testing.T) {
+	type Inner struct {
+		When time.Time
+	}
+	type Outer struct {
+		Inner Inner
+	}
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		Inner: Inner{
+			When: time.Unix(0, 0).UTC(),
+		},
+	})
+
+	assert.Contains(t, out, "... (max depth)")
+	assert.NotContains(t, out, "1970-01-01")
+}
+
+func TestIsComplexValue(t *testing.T) {
+	assert.False(t, isComplexValue(reflect.Value{}))
+
+	var ifaceHolder struct {
+		V any
+	}
+	ifaceVal := reflect.ValueOf(ifaceHolder).Field(0)
+	assert.False(t, isComplexValue(ifaceVal))
+
+	ifaceHolder = struct{ V any }{V: struct{}{}}
+	ifaceVal = reflect.ValueOf(ifaceHolder).Field(0)
+	assert.True(t, isComplexValue(ifaceVal))
+
+	var ptr *int
+	assert.False(t, isComplexValue(reflect.ValueOf(ptr)))
+
+	assert.False(t, isComplexValue(reflect.ValueOf(1)))
+	assert.True(t, isComplexValue(reflect.ValueOf(struct{}{})))
+}
+
+func TestMaxDepthBlocksNestedMapValues(t *testing.T) {
+	v := map[string]map[string]int{
+		"outer": {
+			"inner": 1,
+		},
+	}
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(v)
+
+	assert.Contains(t, out, "outer")
+	assert.Contains(t, out, "... (max depth)")
+	assert.NotContains(t, out, "inner")
+}
+
+func TestMaxDepthAllowsSliceScalars(t *testing.T) {
+	type Inner struct {
+		Values []int
+	}
+	type Outer struct {
+		Inner Inner
+	}
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		Inner: Inner{
+			Values: []int{1, 2},
+		},
+	})
+
+	assert.Contains(t, out, "... (max depth)")
+	assert.NotContains(t, out, "0 => 1")
+}
+
+func TestMaxDepthAllowsPointerScalars(t *testing.T) {
+	type Inner struct {
+		ID *int
+	}
+	type Outer struct {
+		Inner Inner
+	}
+	id := 42
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		Inner: Inner{
+			ID: &id,
+		},
+	})
+
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "42")
+	assert.NotContains(t, out, "... (max depth)")
+}
+
+func TestMaxDepthAllowsPointerStructFields(t *testing.T) {
+	type Inner struct {
+		Name string
+	}
+	type Outer struct {
+		Inner *Inner
+	}
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		Inner: &Inner{Name: "alpha"},
+	})
+
+	assert.Contains(t, out, "alpha")
+	assert.NotContains(t, out, "... (max depth)")
+}
+
+func TestMaxDepthAllowsInterfaceScalar(t *testing.T) {
+	type Outer struct {
+		Value any
+	}
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		Value: "hello",
+	})
+
+	assert.Contains(t, out, `"hello"`)
+	assert.NotContains(t, out, "... (max depth)")
+}
+
+func TestMaxDepthAllowsInterfaceStructFields(t *testing.T) {
+	type Inner struct {
+		Name string
+	}
+	type Outer struct {
+		Value any
+	}
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		Value: Inner{Name: "alpha"},
+	})
+
+	assert.Contains(t, out, "alpha")
+	assert.NotContains(t, out, "... (max depth)")
+}
+
+func TestMaxDepthAllowsArrayScalars(t *testing.T) {
+	type Inner struct {
+		Values [2]int
+	}
+	type Outer struct {
+		Inner Inner
+	}
+
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		Inner: Inner{
+			Values: [2]int{1, 2},
+		},
+	})
+
+	assert.Contains(t, out, "... (max depth)")
+	assert.NotContains(t, out, "0 => 1")
+}
+
+func TestMaxDepthEdgeCases(t *testing.T) {
+	type Inner struct {
+		ID int
+	}
+	type Outer struct {
+		MapVal      map[string]int
+		SliceVal    []int
+		ArrayVal    [2]int
+		MapPtr      *map[string]int
+		StructPtr   *Inner
+		Interface   any
+		NilMap      map[string]int
+		NilSlice    []int
+		NilSlicePtr *[]int
+	}
+
+	m := map[string]int{"key": 1}
+	s := []int{1, 2}
+	a := [2]int{3, 4}
+	out := newDumperT(t, WithMaxDepth(1)).DumpStr(Outer{
+		MapVal:      m,
+		SliceVal:    s,
+		ArrayVal:    a,
+		MapPtr:      &m,
+		StructPtr:   &Inner{ID: 7},
+		Interface:   Inner{ID: 9},
+		NilMap:      nil,
+		NilSlice:    nil,
+		NilSlicePtr: nil,
+	})
+
+	assert.Contains(t, out, "MapVal")
+	assert.Contains(t, out, "... (max depth)")
+	assert.NotContains(t, out, "key")
+	assert.NotContains(t, out, "0 => 1")
+	assert.NotContains(t, out, "0 => 3")
+
+	assert.Contains(t, out, "StructPtr")
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "7")
+
+	assert.Contains(t, out, "Interface")
+	assert.Contains(t, out, "9")
+
+	assert.Contains(t, out, "NilMap")
+	assert.Contains(t, out, "map[string]int(nil)")
+	assert.Contains(t, out, "NilSlice")
+	assert.Contains(t, out, "[]int(nil)")
+	assert.Contains(t, out, "NilSlicePtr")
+	assert.Contains(t, out, "[]int(nil)")
+}
+
+func TestChanValueRendering(t *testing.T) {
+	var nilCh chan int
+	out := dumpStrT(t, nilCh)
+	assert.Contains(t, out, "chan int(nil)")
+
+	ch := make(chan int)
+	out = dumpStrT(t, ch)
+	assert.Contains(t, out, "chan int")
+}
+
+func TestStringerNilPointer(t *testing.T) {
+	var tptr *time.Time
+	d := newDumperT(t)
+	state := newDumpState()
+	var b strings.Builder
+	tw := tabwriter.NewWriter(&b, 0, 0, 1, ' ', 0)
+	d.printValue(tw, reflect.ValueOf(tptr), 0, state)
+	tw.Flush()
+	out := b.String()
+	assert.Contains(t, out, "time.Time(nil)")
+	assert.NotContains(t, out, "... (max depth)")
+
+	tptr = nil
+	out = d.asStringer(reflect.ValueOf(tptr))
+	assert.Contains(t, out, "time.Time(nil)")
+}
+
 func TestMapOutput(t *testing.T) {
 	m := map[string]int{"a": 1, "b": 2}
 	out := dumpStrT(t, m)


### PR DESCRIPTION
**Changes**

- Adjusted max‑depth behavior to truncate only complex container types at the depth boundary while still printing scalar fields.
- Fixed Stringer/max‑depth interaction so Stringers no longer bypass depth limits, and nil values render consistently.
- Expanded max‑depth test coverage across maps, slices, arrays, pointers, interfaces, and nil containers.

Addresses https://github.com/goforj/godump/issues/45