### PR TITLE
feat: Implement WithoutHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ If a pointer has already been printed:
 | **Dump** | [Dd](#dd) [Dump](#dump) [DumpStr](#dumpstr) [Fdump](#fdump) |
 | **HTML** | [DumpHTML](#dumphtml) |
 | **JSON** | [DumpJSON](#dumpjson) [DumpJSONStr](#dumpjsonstr) |
-| **Options** | [WithDisableStringer](#withdisablestringer) [WithMaxDepth](#withmaxdepth) [WithMaxItems](#withmaxitems) [WithMaxStringLen](#withmaxstringlen) [WithNoHeader](#withnoheader) [WithSkipStackFrames](#withskipstackframes) [WithWriter](#withwriter) [WithoutColor](#withoutcolor) |
+| **Options** | [WithDisableStringer](#withdisablestringer) [WithMaxDepth](#withmaxdepth) [WithMaxItems](#withmaxitems) [WithMaxStringLen](#withmaxstringlen) [WithoutHeader](#withoutheader) [WithSkipStackFrames](#withskipstackframes) [WithWriter](#withwriter) [WithoutColor](#withoutcolor) |
 
 
 ## Builder
@@ -581,13 +581,13 @@ d.Dump(v)
 // "hello…" #string
 ```
 
-### <a id="withnoheader"></a>WithNoHeader
+### <a id="withoutheader"></a>WithoutHeader
 
-WithNoHeader disables printing the source location header.
+WithoutHeader disables printing the source location header.
 
 ```go
 // Default: false
-d := godump.NewDumper(godump.WithNoHeader())
+d := godump.NewDumper(godump.WithoutHeader())
 d.Dump("hello")
 // "hello" #string
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://goreportcard.com/report/github.com/goforj/godump"><img src="https://goreportcard.com/badge/github.com/goforj/godump" alt="Go Report Card"></a>
     <a href="https://codecov.io/gh/goforj/godump" ><img src="https://codecov.io/gh/goforj/godump/graph/badge.svg?token=ULUTXL03XC"/></a>
 <!-- test-count:embed:start -->
-    <img src="https://img.shields.io/badge/tests-127-brightgreen" alt="Tests">
+    <img src="https://img.shields.io/badge/tests-130-brightgreen" alt="Tests">
 <!-- test-count:embed:end -->
     <a href="https://github.com/avelino/awesome-go?tab=readme-ov-file#parsersencodersdecoders"><img src="https://awesome.re/mentioned-badge-flat.svg" alt="Mentioned in Awesome Go"></a>
 </p>
@@ -236,7 +236,7 @@ If a pointer has already been printed:
 | **Dump** | [Dd](#dd) [Dump](#dump) [DumpStr](#dumpstr) [Fdump](#fdump) |
 | **HTML** | [DumpHTML](#dumphtml) |
 | **JSON** | [DumpJSON](#dumpjson) [DumpJSONStr](#dumpjsonstr) |
-| **Options** | [WithDisableStringer](#withdisablestringer) [WithMaxDepth](#withmaxdepth) [WithMaxItems](#withmaxitems) [WithMaxStringLen](#withmaxstringlen) [WithSkipStackFrames](#withskipstackframes) [WithWriter](#withwriter) [WithoutColor](#withoutcolor) |
+| **Options** | [WithDisableStringer](#withdisablestringer) [WithMaxDepth](#withmaxdepth) [WithMaxItems](#withmaxitems) [WithMaxStringLen](#withmaxstringlen) [WithNoHeader](#withnoheader) [WithSkipStackFrames](#withskipstackframes) [WithWriter](#withwriter) [WithoutColor](#withoutcolor) |
 
 
 ## Builder
@@ -579,6 +579,17 @@ v := "hello world"
 d := godump.NewDumper(godump.WithMaxStringLen(5))
 d.Dump(v)
 // "hello…" #string
+```
+
+### <a id="withnoheader"></a>WithNoHeader
+
+WithNoHeader disables printing the source location header.
+
+```go
+// Default: false
+d := godump.NewDumper(godump.WithNoHeader())
+d.Dump("hello")
+// "hello" #string
 ```
 
 ### <a id="withskipstackframes"></a>WithSkipStackFrames

--- a/diff.go
+++ b/diff.go
@@ -178,6 +178,9 @@ func (d *Dumper) dumpStrNoHeader(vs ...any) string {
 
 // printDiffHeader writes the diff header line when a caller frame is available.
 func (d *Dumper) printDiffHeader(out io.Writer) {
+	if d.disableHeader {
+		return
+	}
 	file, line := d.findFirstNonInternalFrame(d.skippedStackFrames)
 	if file == "" {
 		return

--- a/diff_test.go
+++ b/diff_test.go
@@ -104,6 +104,16 @@ func TestDiffStrNoColor(t *testing.T) {
 	assert.Contains(t, out, `+ "b" #string`)
 }
 
+func TestDiffStrNoHeader(t *testing.T) {
+	d := NewDumper(WithNoHeader())
+	d.colorizer = colorizeUnstyled
+	out := d.DiffStr(1, 2)
+	out = stripANSI(out)
+	assert.NotContains(t, out, "<#diff")
+	assert.Contains(t, out, "- 1")
+	assert.Contains(t, out, "+ 2")
+}
+
 func TestDiffHTMLNoColor(t *testing.T) {
 	out := NewDumper(WithoutColor()).DiffHTML("a", "b")
 	assert.NotContains(t, out, `<span style="color:`)

--- a/diff_test.go
+++ b/diff_test.go
@@ -105,7 +105,7 @@ func TestDiffStrNoColor(t *testing.T) {
 }
 
 func TestDiffStrNoHeader(t *testing.T) {
-	d := NewDumper(WithNoHeader())
+	d := NewDumper(WithoutHeader())
 	d.colorizer = colorizeUnstyled
 	out := d.DiffStr(1, 2)
 	out = stripANSI(out)

--- a/examples/withnoheader/main.go
+++ b/examples/withnoheader/main.go
@@ -1,0 +1,16 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import "github.com/goforj/godump"
+
+func main() {
+	// WithNoHeader disables printing the source location header.
+
+	// Example: disable header
+	// Default: false
+	d := godump.NewDumper(godump.WithNoHeader())
+	d.Dump("hello")
+	// "hello" #string
+}

--- a/examples/withoutheader/main.go
+++ b/examples/withoutheader/main.go
@@ -6,11 +6,11 @@ package main
 import "github.com/goforj/godump"
 
 func main() {
-	// WithNoHeader disables printing the source location header.
+	// WithoutHeader disables printing the source location header.
 
 	// Example: disable header
 	// Default: false
-	d := godump.NewDumper(godump.WithNoHeader())
+	d := godump.NewDumper(godump.WithoutHeader())
 	d.Dump("hello")
 	// "hello" #string
 }

--- a/godump.go
+++ b/godump.go
@@ -94,6 +94,7 @@ type Dumper struct {
 	skippedStackFrames int
 	disableStringer    bool
 	disableColor       bool
+	disableHeader      bool
 
 	// callerFn is used to get the caller information.
 	// It defaults to [runtime.Caller], it is here to be overridden for testing purposes.
@@ -266,6 +267,22 @@ func WithoutColor() Option {
 	return func(d *Dumper) *Dumper {
 		d.disableColor = true
 		d.colorizer = colorizeUnstyled
+		return d
+	}
+}
+
+// WithNoHeader disables printing the source location header.
+// @group Options
+//
+// Example: disable header
+//
+//	// Default: false
+//	d := godump.NewDumper(godump.WithNoHeader())
+//	d.Dump("hello")
+//	// "hello" #string
+func WithNoHeader() Option {
+	return func(d *Dumper) *Dumper {
+		d.disableHeader = true
 		return d
 	}
 }
@@ -553,6 +570,9 @@ func (d *Dumper) ensureColorizer() {
 
 // printDumpHeader prints the header for the dump output, including the file and line number.
 func (d *Dumper) printDumpHeader(out io.Writer) {
+	if d.disableHeader {
+		return
+	}
 	file, line := d.findFirstNonInternalFrame(d.skippedStackFrames)
 	if file == "" {
 		return

--- a/godump.go
+++ b/godump.go
@@ -271,16 +271,16 @@ func WithoutColor() Option {
 	}
 }
 
-// WithNoHeader disables printing the source location header.
+// WithoutHeader disables printing the source location header.
 // @group Options
 //
 // Example: disable header
 //
 //	// Default: false
-//	d := godump.NewDumper(godump.WithNoHeader())
+//	d := godump.NewDumper(godump.WithoutHeader())
 //	d.Dump("hello")
 //	// "hello" #string
-func WithNoHeader() Option {
+func WithoutHeader() Option {
 	return func(d *Dumper) *Dumper {
 		d.disableHeader = true
 		return d

--- a/godump_test.go
+++ b/godump_test.go
@@ -221,7 +221,7 @@ func TestDumpStrNoColor(t *testing.T) {
 }
 
 func TestDumpStrNoHeader(t *testing.T) {
-	out := newDumperT(t, WithNoHeader()).DumpStr("x")
+	out := newDumperT(t, WithoutHeader()).DumpStr("x")
 	assert.NotContains(t, out, "<#dump")
 	assert.Contains(t, out, `"x"`)
 }

--- a/godump_test.go
+++ b/godump_test.go
@@ -220,6 +220,12 @@ func TestDumpStrNoColor(t *testing.T) {
 	assert.Contains(t, out, `"x"`)
 }
 
+func TestDumpStrNoHeader(t *testing.T) {
+	out := newDumperT(t, WithNoHeader()).DumpStr("x")
+	assert.NotContains(t, out, "<#dump")
+	assert.Contains(t, out, `"x"`)
+}
+
 func TestDiffStr(t *testing.T) {
 	type User struct {
 		Name string


### PR DESCRIPTION
**Changes**

Implements ability to not display the header to users if so desired. Default (false)

**Example**

```go
func main() {
	// WithoutHeader disables printing the source location header.

	// Example: disable header
	// Default: false
	d := godump.NewDumper(godump.WithoutHeader())
	d.Dump("hello")
	// "hello" #string
}
```