### PR TITLE
docs: use absolute README image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/godump.png" width="350" alt="godump logo – Go pretty printer and Laravel-style dump/dd debugging tool">
+  <img src="https://raw.githubusercontent.com/goforj/godump/main/docs/godump.png" width="350" alt="godump logo – Go pretty printer and Laravel-style dump/dd debugging tool">
 </p>
 
 <p align="center">


### PR DESCRIPTION
Uses an absolute raw.githubusercontent.com URL for the leading README image so external link-preview scrapers can load the project artwork consistently.