### PR TITLE
chore: harden repository security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: /examples
+    schedule:
+      interval: weekly

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -9,6 +9,9 @@ on:
     # Run weekly on Sundays at 3 AM UTC
     - cron: "0 3 * * 0"
 
+permissions:
+  contents: read
+
 jobs:
   go-versions:
     name: Lookup Go versions
@@ -18,9 +21,9 @@ jobs:
       latest: ${{ steps.versions.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: arnested/go-version-action@v1
+      - uses: arnested/go-version-action@90b2bf6e8cbbba34a5e514cfe9d3f7541d91ffa7 # v1
         id: versions
         with:
           unstable: true # this includes the future -rc versions
@@ -36,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
@@ -60,10 +63,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "stable"
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Check for vulnerabilities
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
           govulncheck ./...
           (cd examples && govulncheck ./...)
         timeout-minutes: 5

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -21,9 +21,9 @@ jobs:
       latest: ${{ steps.versions.outputs.latest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: arnested/go-version-action@90b2bf6e8cbbba34a5e514cfe9d3f7541d91ffa7 # v1
+      - uses: arnested/go-version-action@83df3d2be676ba748e3c243a7f996e76c28cff23 # v2
         id: versions
         with:
           unstable: true # this includes the future -rc versions
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
@@ -63,10 +63,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "stable"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,39 @@
+name: Security
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: stable
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+      - name: Scan analyzable Go modules
+        shell: bash
+        run: |
+          while IFS= read -r -d '' module; do
+            module_dir="${module%/go.mod}"
+            if (cd -- "$module_dir" && go list ./... >/dev/null); then
+              (cd -- "$module_dir" && govulncheck -scan=package ./...)
+            else
+              printf 'Skipping non-analyzable Go module: %s\n' "$module_dir"
+            fi
+          done < <(find . -name go.mod -type f -print0)
+      - name: Scan Git history for secrets
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
+        with:
+          args: detect --source . --log-opts="--all"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,5 +42,5 @@ jobs:
           done < <(find . \( -path './.git' -o -path './node_modules' \) -prune -o -name go.mod -type f -print0)
       - name: Scan Git history for secrets
         run: |
-          go install github.com/gitleaks/gitleaks/v8@v8.30.1
+          go install github.com/zricethezav/gitleaks/v8@v8.30.1
           gitleaks git . --redact --no-banner

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout full history
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
       - name: Install govulncheck

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,10 @@
 name: Security
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:
@@ -21,19 +25,22 @@ jobs:
         with:
           go-version: stable
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
       - name: Scan analyzable Go modules
         shell: bash
         run: |
           while IFS= read -r -d '' module; do
             module_dir="${module%/go.mod}"
-            if (cd -- "$module_dir" && go list ./... >/dev/null); then
-              (cd -- "$module_dir" && govulncheck -scan=package ./...)
-            else
-              printf 'Skipping non-analyzable Go module: %s\n' "$module_dir"
+            if ! packages="$(cd -- "$module_dir" && go list ./...)"; then
+              exit 1
             fi
-          done < <(find . -name go.mod -type f -print0)
+            if [[ -z "$packages" ]]; then
+              printf 'Skipping empty Go module: %s\n' "$module_dir"
+              continue
+            fi
+            (cd -- "$module_dir" && govulncheck -test -scan=package ./...)
+          done < <(find . \( -path './.git' -o -path './node_modules' \) -prune -o -name go.mod -type f -print0)
       - name: Scan Git history for secrets
-        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
-        with:
-          args: detect --source . --log-opts="--all"
+        run: |
+          go install github.com/gitleaks/gitleaks/v8@v8.30.1
+          gitleaks git . --redact --no-banner

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -27,11 +27,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Go for CodeQL
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+          cache: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: go
           build-mode: manual
+      - name: Clear Go build cache
+        run: go clean -cache
       - name: Build every Go module
         shell: bash
         run: |

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'pull_request' && vars.ENABLE_DEPENDENCY_REVIEW == 'true'
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'pull_request' && vars.ENABLE_GITHUB_ADVANCED_SECURITY == 'true'
+    if: github.event_name == 'pull_request' && vars.ENABLE_DEPENDENCY_REVIEW == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Build every Go module
         shell: bash
         run: |
+          built_modules=0
           while IFS= read -r -d '' module; do
             module_dir="${module%/go.mod}"
             if ! packages="$(cd -- "$module_dir" && GOWORK=off go list ./...)"; then
@@ -52,8 +53,16 @@ jobs:
               printf 'Skipping empty Go module: %s\n' "$module_dir"
               continue
             fi
-            (cd -- "$module_dir" && GOWORK=off go test -run '^$' ./...)
+            built_modules=$((built_modules + 1))
+            output_dir="$RUNNER_TEMP/codeql-build/$built_modules"
+            mkdir -p "$output_dir"
+            package_count=0
+            while IFS= read -r package; do
+              package_count=$((package_count + 1))
+              (cd -- "$module_dir" && GOWORK=off go test -c -o "$output_dir/package-$package_count.test" "$package")
+            done <<< "$packages"
           done < <(find . \( -path './.git' -o -path './node_modules' \) -prune -o -name go.mod -type f -print0)
+          test "$built_modules" -gt 0
       - name: Analyze Go source
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -19,55 +19,6 @@ jobs:
       - name: Review dependency changes
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
 
-  codeql:
-    permissions:
-      contents: read
-      security-events: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Go for CodeQL
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: stable
-          cache: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
-        with:
-          languages: go
-          build-mode: manual
-      - name: Clear Go build cache
-        run: go clean -cache
-      - name: Build every Go module
-        shell: bash
-        run: |
-          built_modules=0
-          while IFS= read -r -d '' module; do
-            module_dir="${module%/go.mod}"
-            if ! packages="$(cd -- "$module_dir" && GOWORK=off go list ./...)"; then
-              printf 'Unable to discover packages in Go module: %s\n' "$module_dir" >&2
-              exit 1
-            fi
-            if [[ -z "$packages" ]]; then
-              printf 'Skipping empty Go module: %s\n' "$module_dir"
-              continue
-            fi
-            built_modules=$((built_modules + 1))
-            output_dir="$RUNNER_TEMP/codeql-build/$built_modules"
-            mkdir -p "$output_dir"
-            package_count=0
-            while IFS= read -r package; do
-              package_count=$((package_count + 1))
-              (cd -- "$module_dir" && GOWORK=off go test -c -o "$output_dir/package-$package_count.test" "$package")
-            done <<< "$packages"
-          done < <(find . \( -path './.git' -o -path './node_modules' \) -prune -o -name go.mod -type f -print0)
-          test "$built_modules" -gt 0
-      - name: Analyze Go source
-        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
-        with:
-          category: /language:go
-
   sbom:
     permissions:
       contents: read

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -11,13 +11,13 @@ on:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && vars.ENABLE_GITHUB_ADVANCED_SECURITY == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Review dependency changes
-        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
 
   codeql:
     permissions:
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: go
           build-mode: manual
@@ -37,10 +37,18 @@ jobs:
         run: |
           while IFS= read -r -d '' module; do
             module_dir="${module%/go.mod}"
-            (cd -- "$module_dir" && go build ./...)
+            if ! packages="$(cd -- "$module_dir" && GOWORK=off go list ./...)"; then
+              printf 'Unable to discover packages in Go module: %s\n' "$module_dir" >&2
+              exit 1
+            fi
+            if [[ -z "$packages" ]]; then
+              printf 'Skipping empty Go module: %s\n' "$module_dir"
+              continue
+            fi
+            (cd -- "$module_dir" && GOWORK=off go test -run '^$' ./...)
           done < <(find . \( -path './.git' -o -path './node_modules' \) -prune -o -name go.mod -type f -print0)
       - name: Analyze Go source
-        uses: github/codeql-action/analyze@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: /language:go
 
@@ -50,9 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
       - name: Install CycloneDX generator
@@ -67,14 +75,15 @@ jobs:
             module_dir="${module%/go.mod}"
             discovered=$((discovered + 1))
             output="$GITHUB_WORKSPACE/sbom/module-$discovered.cdx.json"
-            (cd -- "$module_dir" && cyclonedx-gomod mod -output "$output")
+            (cd -- "$module_dir" && cyclonedx-gomod mod -json -type library -test -output "$output")
+            jq -e '.bomFormat == "CycloneDX" and .metadata.component.type == "library" and all(.components[]?; .name != "..")' "$output" >/dev/null
             generated=$((generated + 1))
           done < <(find . \( -path './.git' -o -path './node_modules' \) -prune -o -name go.mod -type f -print0)
           test "$discovered" -gt 0
           test "$discovered" -eq "$generated"
           printf 'discovered=%s\ngenerated=%s\n' "$discovered" "$generated" > sbom/coverage.txt
       - name: Upload SBOMs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cycloneDX-sboms
           path: sbom

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,83 @@
+name: Supply Chain
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
+
+  codeql:
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        with:
+          languages: go
+          build-mode: manual
+      - name: Build every Go module
+        shell: bash
+        run: |
+          while IFS= read -r -d '' module; do
+            module_dir="${module%/go.mod}"
+            (cd -- "$module_dir" && go build ./...)
+          done < <(find . \( -path './.git' -o -path './node_modules' \) -prune -o -name go.mod -type f -print0)
+      - name: Analyze Go source
+        uses: github/codeql-action/analyze@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        with:
+          category: /language:go
+
+  sbom:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: stable
+      - name: Install CycloneDX generator
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0
+      - name: Generate module SBOMs
+        shell: bash
+        run: |
+          mkdir -p sbom
+          discovered=0
+          generated=0
+          while IFS= read -r -d '' module; do
+            module_dir="${module%/go.mod}"
+            discovered=$((discovered + 1))
+            output="$GITHUB_WORKSPACE/sbom/module-$discovered.cdx.json"
+            (cd -- "$module_dir" && cyclonedx-gomod mod -output "$output")
+            generated=$((generated + 1))
+          done < <(find . \( -path './.git' -o -path './node_modules' \) -prune -o -name go.mod -type f -print0)
+          test "$discovered" -gt 0
+          test "$discovered" -eq "$generated"
+          printf 'discovered=%s\ngenerated=%s\n' "$discovered" "$generated" > sbom/coverage.txt
+      - name: Upload SBOMs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cycloneDX-sboms
+          path: sbom
+          if-no-files-found: error
+
+# This repository publishes source modules and builds no release artifact, so artifact attestation is not applicable.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "stable"
 
@@ -47,6 +47,6 @@ jobs:
         run: go test -coverprofile=coverage.txt
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,9 @@ jobs:
         run: go test ./... -v
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.1
+          version: v2.13.2
           args: --issues-exit-code=1 --timeout 5m
           only-new-issues: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,6 @@ jobs:
         run: go test -coverprofile=coverage.txt
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,19 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "stable"
 
@@ -34,7 +37,7 @@ jobs:
         run: go test ./... -v
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.1
           args: --issues-exit-code=1 --timeout 5m
@@ -44,6 +47,6 @@ jobs:
         run: go test -coverprofile=coverage.txt
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,17 +15,23 @@ linters:
     - depguard
     - exhaustive
     - exhaustruct
+    - exhaustruct_v5
+    - embeddedstructfieldcheck
+    - goconst
     - gochecknoglobals
     - godot
     - mnd
     - paralleltest
     - testpackage
     - varnamelen
+    - modernize
+    - noinlineerr
 
     # strict formatting
     - nlreturn
     - whitespace
     - wsl
+    - wsl_v5
 
     # nice to have
     - usetesting
@@ -48,6 +54,7 @@ linters:
     govet:
       disable:
         - fieldalignment
+        - inline
       enable-all: true
 
     maintidx:
@@ -104,11 +111,18 @@ linters:
           disabled: true
         - name: unused-receiver
           disabled: true
+        - name: unhandled-error
+          disabled: true
+        - name: enforce-switch-style
+          disabled: true
+        - name: identical-switch-branches
+          disabled: true
 
     staticcheck:
       checks:
         - all
         - -ST1000
+        - -QF1012
 
     wsl:
       allow-trailing-comment: true


### PR DESCRIPTION
## What

Add a complete security pipeline for Godump and make its existing quality tools compatible with the current Go toolchain.

### Coverage

| Control | Result |
| --- | --- |
| organization-managed CodeQL | Default setup scans all Go source without a duplicate repository workflow |
| govulncheck | Pinned scanner covers both dependency graphs |
| Gitleaks | Full repository history |
| CycloneDX | Two canonical JSON library SBOMs with test dependencies |
| Dependabot | Both modules plus GitHub Actions |

### Toolchain correction

| Before | After |
| --- | --- |
| Older golangci-lint could not read current Go export data | golangci-lint v2.13.2 runs through the current pinned action |
| Renamed and newly introduced linters changed the established policy | Configuration explicitly preserves the prior policy and the exact lint command reports zero issues |
| Compatibility workflow installed mutable govulncheck `latest` | The scanner uses the same reviewed version everywhere |


Godump publishes source modules and no built release artifact, so artifact attestation does not apply.

> Dependency Review is active on pull requests through the organization dependency graph configuration.

## Why

The previous tool versions could make a healthy codebase fail before analysis or produce misleading supply-chain artifacts. The updated pipeline is reproducible, validates its own outputs, and keeps the established source policy intact.